### PR TITLE
Setup travis to use stages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,30 @@ script:
 
   - make test args='--verbose'
 
-  # create tag
-  - git config --global user.email "ci@smartcar.com"
-  - git config --global user.name "Travis CI User"
-  - export tag=$(cat smartcar/__init__.py | grep '^__version__' | sed "s/^__version__[[:blank:]]*=[[:blank:]]'\(.*\)'/\1/g")
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then git tag -a v$tag -m "Travis Generated Tag"; fi
+jobs:
+  include:
+    - stage: tag
+      language: generic
+      install: false
+      script:
+        - git config --global user.email "ci@smartcar.com"
+        - git config --global user.name "Travis CI User"
+        - export tag=$(cat smartcar/__init__.py | grep '^__version__' | sed "s/^__version__[[:blank:]]*=[[:blank:]]'\(.*\)'/\1/g")
+        - if [ "$TRAVIS_BRANCH" = "master" ]; then git tag -a v$tag -m "Travis Generated Tag"; fi
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:  echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc && git push origin v$tag
+        on:
+          branch: master
 
-deploy:
-
-  - provider: script
-    skip_cleanup: true
-    script: echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc && git push origin v$tag
-    on:
-      branch: master
-      python: 3.6
-
-  - provider: pypi
-    user: $PYPI_USERNAME
-    password: $PYPI_PASSWORD
-    on:
-      branch: master
-      python: 3.6
+    - stage: publish
+      language: generic
+      install: false
+      script: false
+      deploy:
+        provider: pypi
+        user: $PYPI_USERNAME
+        password: $PYPI_PASSWORD
+        on:
+          branch: master

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 from .const import (API_VERSION, API_URL, AUTH_URL, UNIT_HEADER)
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle


### PR DESCRIPTION
This fix serialized the Tag and Publish into separate stages which must run after the test matrix. 

Previously a build on master would fail if it happened to run after the '3.6' build (which pushed the tag). [Example here: `v1.0.2` master build](https://travis-ci.com/smartcar/python-sdk/builds/72371821)