### PR TITLE
Use unit system from response header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@ Initializes a new Vehicle to use for making requests to the Smartcar API.
 | `access_token`  | String | **Required** a valid access token |
 | `unit_system`   | String | **Optional** the unit system to use for vehicle data. Defaults to metric. |
 
-### `set_unit(self, unit)`
+### `set_unit_system(self, unit_system)`
 
 Update the unit system to use in requests to the Smartcar API.
 
 #### Arguments
 | Parameter       | Type | Description   |
 |:--------------- |:---- |:------------- |
-| `unit`          | String | the unit system to use (metric/imperial) |
+| `unit_system`          | String | the unit system to use (metric/imperial) |
 
 ### `permissions(self)`
 

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,5 +1,4 @@
-__version__ = '1.0.3'
-from .const import (API_VERSION, API_URL, AUTH_URL, UNIT_HEADER)
+__version__ = '1.0.4'
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle
 from .exceptions import (

--- a/smartcar/api.py
+++ b/smartcar/api.py
@@ -14,16 +14,16 @@ class Api(object):
         self.auth = {
             'Authorization': 'Bearer {}'.format(access_token)
         }
-        self.unit = 'metric'
+        self.unit_system = 'metric'
 
-    def set_unit(self, unit):
+    def set_unit_system(self, unit_system):
         """ Update the unit system to use in requests to the Smartcar API.
 
         Args:
-            unit (str): the unit system to use (metric/imperial)
+            unit_system (str): the unit system to use (metric/imperial)
 
         """
-        self.unit = unit
+        self.unit_system = unit_system
 
     def _format(self, endpoint):
         """ Generates the formated URL
@@ -51,7 +51,7 @@ class Api(object):
         """
         url = self._format(endpoint)
         headers = self.auth
-        headers[const.UNIT_HEADER] = self.unit
+        headers[const.UNIT_SYSTEM_HEADER] = self.unit_system
         json = { 'action': action }
         for k,v in kwargs.items():
             if v:
@@ -71,7 +71,7 @@ class Api(object):
         """
         url = self._format(endpoint)
         headers = self.auth
-        headers[const.UNIT_HEADER] = self.unit
+        headers[const.UNIT_SYSTEM_HEADER] = self.unit_system
         return requester.call('GET', url, headers=headers)
 
     def permissions(self, **params):

--- a/smartcar/const.py
+++ b/smartcar/const.py
@@ -2,4 +2,4 @@ API_VERSION = '1.0'
 API_URL = 'https://api.smartcar.com/v{}'.format(API_VERSION)
 AUTH_URL = 'https://auth.smartcar.com/oauth/token'
 CONNECT_URL = 'https://connect.smartcar.com'
-UNIT_HEADER = 'sc-unit-system'
+UNIT_SYSTEM_HEADER = 'sc-unit-system'

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -16,19 +16,19 @@ class Vehicle(object):
         self.vehicle_id = vehicle_id
         self.access_token = access_token
         self.api = Api(access_token, vehicle_id)
-        self.api.set_unit('metric' if unit_system == 'metric' else 'imperial')
+        self.api.set_unit_system('metric' if unit_system == 'metric' else 'imperial')
 
-    def set_unit(self, unit):
+    def set_unit_system(self, unit_system):
         """ Update the unit system to use in requests to the Smartcar API.
 
         Args:
-            unit (str): the unit system to use (metric/imperial)
+            unit_system (str): the unit system to use (metric/imperial)
 
         """
-        if unit not in ('metric','imperial'):
+        if unit_system not in ('metric','imperial'):
             raise ValueError("unit must be either metric or imperial")
         else:
-            self.api.set_unit(unit)
+            self.api.set_unit_system(unit_system)
 
     def info(self):
         """ GET Vehicle.info
@@ -82,7 +82,7 @@ class Vehicle(object):
 
         return {
             'data': response.json(),
-            'unit_system': self.api.unit,
+            'unit_system': response.headers['sc-unit-system'],
             'age': dateutil.parser.parse(response.headers['sc-data-age']),
         }
 


### PR DESCRIPTION
The main change is this in `vehicle.py`:

```diff
-            'unit_system': self.api.unit,
+            'unit_system': response.headers['sc-unit-system'],
```

The header was previously being pulled from the `self` not the response header.