### PR TITLE
Update development flag to test_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make test args="--verbose"
 Now that you have your id, secret and redirect URI, here's a simple overall idea of how to use the SDK to authenticate and make requests with the Smartcar API.
 
 * Import the sdk `import smartcar`
-* Create a new smartcar `client` with `smartcar.AuthClient(client_id, client_secret, redirect_uri, scope, development)`
+* Create a new smartcar `client` with `smartcar.AuthClient(client_id, client_secret, redirect_uri, scope, test_mode)`
 * Redirect the user to an OEM login page using the URL from `client.get_auth_url()`
 * The user will login, and then accept or deny the permissions in your `scope`
     * If the user is already connected to your application, they will not be shown the accept or deny dialog. However the application can force this dialog to be shown with `client.get_auth_url(force=True)`
@@ -118,7 +118,7 @@ odometer = vehicle.odometer()['data']['distance']
 
 ## AuthClient
 
-### `smartcar.AuthClient(self, client_id, client_secret, redirect_uri, scope=None, development=False)`
+### `smartcar.AuthClient(self, client_id, client_secret, redirect_uri, scope=None, test_mode=False)`
 
 A client for accessing the Smartcar API
 
@@ -129,7 +129,7 @@ A client for accessing the Smartcar API
 | `client_secret` | String |**Required** Application clientSecret obtained from [Smartcar Developer Portal](https://developer.smartcar.com). If you do not have access to the dashboard, please [request access](https://smartcar.com/subscribe). |
 | `redirect_uri`  | String |**Required** RedirectURI set in [application settings](https://developer.smartcar.com/apps). Given URL must match URL in application settings. |
 | `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
-| `development`   | Boolean |**Optional** Launch Smartcar auth in development mode to enable the mock vehicle brand. |
+| `test_mode`   | Boolean |**Optional** Launch Smartcar auth in test mode to enable the mock vehicle brand. |
 
 ### `get_auth_url(self, force=False, state=None)`
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A client for accessing the Smartcar API
 | `redirect_uri`  | String |**Required** RedirectURI set in [application settings](https://developer.smartcar.com/apps). Given URL must match URL in application settings. |
 | `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
 | `test_mode`   | Boolean |**Optional** Launch the Smartcar auth flow in test mode. |
+| `development`   | Boolean |**Optional** DEPRECATED Launch the Smartcar auth flow in development mode to enable mock vehicle brands. |
 
 ### `get_auth_url(self, force=False, state=None)`
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A client for accessing the Smartcar API
 | `client_secret` | String |**Required** Application clientSecret obtained from [Smartcar Developer Portal](https://developer.smartcar.com). If you do not have access to the dashboard, please [request access](https://smartcar.com/subscribe). |
 | `redirect_uri`  | String |**Required** RedirectURI set in [application settings](https://developer.smartcar.com/apps). Given URL must match URL in application settings. |
 | `scope`         | String[] |**Optional** List of permissions your application requires. This will default to requiring all scopes. The valid permission names are found in the [API Reference](https://smartcar.com/docs#get-all-vehicles). |
-| `test_mode`   | Boolean |**Optional** Launch Smartcar auth in test mode to enable the mock vehicle brand. |
+| `test_mode`   | Boolean |**Optional** Launch the Smartcar auth flow in test mode. |
 
 ### `get_auth_url(self, force=False, state=None)`
 

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.0'
+__version__ = '1.0.10'
 
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.9'
+__version__ = '2.0.0'
 
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -65,7 +65,7 @@ class AuthClient(object):
                 or declines the application's permissions. This URL must also be
                 present in the Redirect URIs field in the application dashboard
             scope (bool, optional): A list of permissions requested by the application
-            test_mode (bool, optional): Launch smartcar auth flow in test mode. Defaults to false.
+            test_mode (bool, optional): Launch the Smartcar auth flow in test mode. Defaults to false.
               https://smartcar.com/docs#request-authorization
 
         """

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -53,7 +53,7 @@ def get_user_id(access_token):
 
 class AuthClient(object):
 
-    def __init__(self, client_id, client_secret, redirect_uri, scope=None, test_mode=False):
+    def __init__(self, client_id, client_secret, redirect_uri, scope=None, test_mode=None, development=None):
         """ A client for accessing the Smartcar API
 
         Args:
@@ -66,7 +66,9 @@ class AuthClient(object):
                 present in the Redirect URIs field in the application dashboard
             scope (bool, optional): A list of permissions requested by the application
             test_mode (bool, optional): Launch the Smartcar auth flow in test mode. Defaults to false.
-              https://smartcar.com/docs#request-authorization
+                https://smartcar.com/docs#request-authorization
+            development (bool, optional): DEPRECATED Launch the Smartcar auth flow in development mode
+                to enable mock vehicle brands.
 
         """
         self.client_id = client_id
@@ -74,7 +76,15 @@ class AuthClient(object):
         self.auth=(client_id, client_secret)
         self.redirect_uri = redirect_uri
         self.scope = scope
-        self.test_mode = test_mode
+
+        if development:
+            import warnings
+            message = """Development flag is deprecated. This is discouraged and will be
+                         removed in the next major release. Use testMode instead."""
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            self.test_mode = development
+        else:
+            self.test_mode = test_mode if test_mode else False
 
     def get_auth_url(self, force=False, state=None):
         """ Generate an OAuth authentication URL

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -53,7 +53,7 @@ def get_user_id(access_token):
 
 class AuthClient(object):
 
-    def __init__(self, client_id, client_secret, redirect_uri, scope=None, development=False):
+    def __init__(self, client_id, client_secret, redirect_uri, scope=None, test_mode=False):
         """ A client for accessing the Smartcar API
 
         Args:
@@ -65,8 +65,8 @@ class AuthClient(object):
                 or declines the application's permissions. This URL must also be
                 present in the Redirect URIs field in the application dashboard
             scope (bool, optional): A list of permissions requested by the application
-            development (bool, optional): If True, deplays the Mock OEM for testing.
-                Defaults to False
+            test_mode (bool, optional): Launch smartcar auth flow in test mode. Defaults to false.
+              https://smartcar.com/docs#request-authorization
 
         """
         self.client_id = client_id
@@ -74,7 +74,7 @@ class AuthClient(object):
         self.auth=(client_id, client_secret)
         self.redirect_uri = redirect_uri
         self.scope = scope
-        self.development = development
+        self.test_mode = test_mode
 
     def get_auth_url(self, force=False, state=None):
         """ Generate an OAuth authentication URL
@@ -100,8 +100,8 @@ class AuthClient(object):
             'approval_prompt': approval_prompt,
         }
 
-        if self.development:
-            query['mock'] = 'true'
+        if self.test_mode:
+            query['mode'] = 'test'
 
         if self.scope:
             query['scope'] = ' '.join(self.scope)

--- a/tests/test_smartcar.py
+++ b/tests/test_smartcar.py
@@ -44,7 +44,7 @@ class TestSmartcar(unittest.TestCase):
 
         self.assertTrue(smartcar.is_expired(access['expiration']))
 
-    def test_get_auth_url(self):
+    def test_get_auth_url_test_mode(self):
         oem = 'audi'
         actual = self.client.get_auth_url(force=True, state='stuff')
         query = urlencode({
@@ -59,9 +59,40 @@ class TestSmartcar(unittest.TestCase):
         expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
         self.assertEqual(actual, expected)
 
-    def test_get_auth_url_live_mode(self):
+    def test_get_auth_url(self):
         client = smartcar.AuthClient(self.client_id, self.client_secret,
                 self.redirect_uri, self.scope, test_mode=False)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_with_development(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope, development=True)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'mode': 'test',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_test_mode_with_development(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope, development=False)
         actual = client.get_auth_url(force=True, state='stuff')
         query = urlencode({
             'response_type': 'code',

--- a/tests/test_smartcar.py
+++ b/tests/test_smartcar.py
@@ -46,6 +46,53 @@ class TestSmartcar(unittest.TestCase):
 
     def test_get_auth_url(self):
         client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_test_mode_true(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope, test_mode=True)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'mode': 'test',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_test_mode_no_keyword_true(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope, True)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'mode': 'test',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_test_mode_false(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
                 self.redirect_uri, self.scope, test_mode=False)
         actual = client.get_auth_url(force=True, state='stuff')
         query = urlencode({
@@ -59,22 +106,7 @@ class TestSmartcar(unittest.TestCase):
         expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
         self.assertEqual(actual, expected)
 
-    def test_get_auth_url_test_mode(self):
-        oem = 'audi'
-        actual = self.client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'mode': 'test',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        self.assertEqual(actual, expected)
-
-    def test_get_auth_url_with_development(self):
+    def test_get_auth_url_development_true(self):
         client = smartcar.AuthClient(self.client_id, self.client_secret,
                 self.redirect_uri, self.scope, development=True)
         actual = client.get_auth_url(force=True, state='stuff')
@@ -90,7 +122,7 @@ class TestSmartcar(unittest.TestCase):
         expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
         self.assertEqual(actual, expected)
 
-    def test_get_auth_url_test_mode_with_development(self):
+    def test_get_auth_url_development_false(self):
         client = smartcar.AuthClient(self.client_id, self.client_secret,
                 self.redirect_uri, self.scope, development=False)
         actual = client.get_auth_url(force=True, state='stuff')

--- a/tests/test_smartcar.py
+++ b/tests/test_smartcar.py
@@ -44,21 +44,6 @@ class TestSmartcar(unittest.TestCase):
 
         self.assertTrue(smartcar.is_expired(access['expiration']))
 
-    def test_get_auth_url_test_mode(self):
-        oem = 'audi'
-        actual = self.client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'mode': 'test',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        self.assertEqual(actual, expected)
-
     def test_get_auth_url(self):
         client = smartcar.AuthClient(self.client_id, self.client_secret,
                 self.redirect_uri, self.scope, test_mode=False)
@@ -68,6 +53,21 @@ class TestSmartcar(unittest.TestCase):
             'client_id': self.client_id,
             'redirect_uri': self.redirect_uri,
             'approval_prompt': 'force',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_test_mode(self):
+        oem = 'audi'
+        actual = self.client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
+            'mode': 'test',
             'scope': ' '.join(self.scope),
             'state': 'stuff'
         })

--- a/tests/test_smartcar.py
+++ b/tests/test_smartcar.py
@@ -52,7 +52,22 @@ class TestSmartcar(unittest.TestCase):
             'client_id': self.client_id,
             'redirect_uri': self.redirect_uri,
             'approval_prompt': 'force',
-            'mock': 'true',
+            'mode': 'test',
+            'scope': ' '.join(self.scope),
+            'state': 'stuff'
+        })
+        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        self.assertEqual(actual, expected)
+
+    def test_get_auth_url_live_mode(self):
+        client = smartcar.AuthClient(self.client_id, self.client_secret,
+                self.redirect_uri, self.scope, test_mode=False)
+        actual = client.get_auth_url(force=True, state='stuff')
+        query = urlencode({
+            'response_type': 'code',
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'approval_prompt': 'force',
             'scope': ' '.join(self.scope),
             'state': 'stuff'
         })

--- a/tests/tests_e2e/test_base.py
+++ b/tests/tests_e2e/test_base.py
@@ -58,14 +58,14 @@ class TestBase(unittest.TestCase):
             'read_location',
             'read_odometer'
         ]
-        development = True
+        test_mode = True
 
         cls.client = smartcar.AuthClient(
             client_id,
             client_secret,
             redirect_uri,
             scope,
-            development
+            test_mode
         )
 
         cls.driver = webdriver.Remote(


### PR DESCRIPTION
Updated `development` to `test_mode` in the `AuthClient` constructor.

Updated unit and e2e tests as appropriate.