### PR TITLE
Correct misspelled function in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Now that you have your id, secret and redirect URI, here's a simple overall idea
 ```python
 def get_fresh_access():
     access = load_access_from_database()
-    if smartcar.expired(access['expiration']):
+    if smartcar.is_expired(access['expiration']):
         new_access = client.exchange_refresh_token(access['refresh_token'])
         put_access_into_database(new_access)
         return new_access

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.12'
+__version__ = '1.0.13'
 
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle


### PR DESCRIPTION
 On line 63 the example that shows how to refresh the access tokes erroneously lists "smartcar.expired()", while the function name should be "smartcar.is_expired()"