### PR TITLE
fix: Fixes breaking e2e test

### DIFF
--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
 from .vehicle import Vehicle

--- a/tests/tests_e2e/test_base.py
+++ b/tests/tests_e2e/test_base.py
@@ -33,11 +33,11 @@ class TestBase(unittest.TestCase):
             username = uuid.uuid4()
             username = str(username) + '@mock.com'
 
-            approval_button = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, 'approval-button')))
+            sign_in_button = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.ID, 'sign-in-button')))
             driver.find_element_by_id('username').send_keys(username)
             driver.find_element_by_id('password').send_keys('password')
-            approval_button.click()
+            sign_in_button.click()
 
             permissions_approval_button = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.ID, 'approval-button')))


### PR DESCRIPTION
Context: I changed the ID of oem-auth's `login.hbs` login button from `approval-button` to `sign-in-button`.