### PR TITLE
WIP: New formatter (black)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,9 @@ services:
   - docker
 
 script:
-
   - docker run --name selenium-container -d --net host -v /dev/shm:/dev/shm selenium/standalone-chrome
-  # Black formatter only works on Python 3.6+
-  - if [[ $TRAVIS_PYTHON_VERSION > '3.59' ]]; then make lint; fi
   - make test args='--verbose'
+  - if [[$TRAVIS_PYTHON_VERSION == '3.6' ]]; then make lint; fi
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
 script:
 
   - docker run --name selenium-container -d --net host -v /dev/shm:/dev/shm selenium/standalone-chrome
+  - make lint
   - make test args='--verbose'
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ services:
 script:
 
   - docker run --name selenium-container -d --net host -v /dev/shm:/dev/shm selenium/standalone-chrome
-  - make lint
+  # Black formatter only works on Python 3.6+
+  - if [[ $TRAVIS_PYTHON_VERSION > '3.59' ]]; then make lint; fi
   - make test args='--verbose'
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,5 +19,8 @@ export INTEGRATION_CLIENT_SECRET=''
 ```
 3. Run tests: `make test args="--verbose"`
 
+## Formatting
+All code in this repository is formatted using [black](https://github.com/python/black). Please format all contributions using the tool.
+
 ## Creating a pull request
 Please make sure to bump the version number in `smartcar/__init__.py` in accordance with [semver](https://semver.org/) when making a pull request to the `master` branch.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ test:
 	nosetests --with-coverage --cover-package=smartcar --cover-html --cover-html-dir=htmlcover $(args) --cover-min-percentage 97 -verbose -d
 
 lint:
-	black . --check
+	black ./smartcar --check
+	black ./tests --check
 
 wheel:
 	python setup.py bdist_wheel --universal

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	nosetests --with-coverage --cover-package=smartcar --cover-html --cover-html-dir=htmlcover $(args) --cover-min-percentage 97 -verbose -d
 
+lint:
+	black . --check
+
 wheel:
 	python setup.py bdist_wheel --universal
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             'responses',
             'selenium',
             'retrying',
+            'black'
         ]
     }
 )

--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -1,10 +1,17 @@
-__version__ = '3.0.4'
+__version__ = "3.0.4"
 
-from .smartcar import (AuthClient, is_expired, get_user_id, get_vehicle_ids)
+from .smartcar import AuthClient, is_expired, get_user_id, get_vehicle_ids
 from .vehicle import Vehicle
 from .exceptions import (
-    SmartcarException, ValidationException, AuthenticationException,
-    PermissionException, ResourceNotFoundException, StateException,
-    RateLimitingException, MonthlyLimitExceeded, ServerException,
-    NotCapableException, GatewayTimeoutException
+    SmartcarException,
+    ValidationException,
+    AuthenticationException,
+    PermissionException,
+    ResourceNotFoundException,
+    StateException,
+    RateLimitingException,
+    MonthlyLimitExceeded,
+    ServerException,
+    NotCapableException,
+    GatewayTimeoutException,
 )

--- a/smartcar/api.py
+++ b/smartcar/api.py
@@ -1,7 +1,7 @@
 from . import const, requester
 
-class Api(object):
 
+class Api(object):
     def __init__(self, access_token, vehicle_id=None):
         """ Initialize a new Api object to make directly make requests to Smartcar.
 
@@ -11,10 +11,8 @@ class Api(object):
         """
         self.access_token = access_token
         self.vehicle_id = vehicle_id
-        self.auth = {
-            'Authorization': 'Bearer {}'.format(access_token)
-        }
-        self.unit_system = 'metric'
+        self.auth = {"Authorization": "Bearer {}".format(access_token)}
+        self.unit_system = "metric"
 
     def set_unit_system(self, unit_system):
         """ Update the unit system to use in requests to the Smartcar API.
@@ -35,7 +33,7 @@ class Api(object):
             str: formatted url
 
         """
-        return '{}/vehicles/{}/{}'.format(const.API_URL, self.vehicle_id, endpoint)
+        return "{}/vehicles/{}/{}".format(const.API_URL, self.vehicle_id, endpoint)
 
     def action(self, endpoint, action, **kwargs):
         """ Sends POST requests to Smartcar API
@@ -52,12 +50,12 @@ class Api(object):
         url = self._format(endpoint)
         headers = self.auth
         headers[const.UNIT_SYSTEM_HEADER] = self.unit_system
-        json = { 'action': action }
-        for k,v in kwargs.items():
+        json = {"action": action}
+        for k, v in kwargs.items():
             if v:
                 json[k] = v
 
-        return requester.call('POST', url, json=json, headers=self.auth)
+        return requester.call("POST", url, json=json, headers=self.auth)
 
     def get(self, endpoint):
         """ Sends GET requests to Smartcar API
@@ -72,7 +70,7 @@ class Api(object):
         url = self._format(endpoint)
         headers = self.auth
         headers[const.UNIT_SYSTEM_HEADER] = self.unit_system
-        return requester.call('GET', url, headers=headers)
+        return requester.call("GET", url, headers=headers)
 
     def permissions(self, **params):
         """ Sends a request to /permissions
@@ -84,8 +82,8 @@ class Api(object):
             Reponse: response from the request to the Smartcar API
 
         """
-        url = self._format('permissions')
-        return requester.call('GET', url, headers=self.auth, params=params)
+        url = self._format("permissions")
+        return requester.call("GET", url, headers=self.auth, params=params)
 
     def disconnect(self):
         """ Sends a request to /application
@@ -94,8 +92,8 @@ class Api(object):
             Response: response from the request to the Smartcar API
 
         """
-        url = self._format('application')
-        return requester.call('DELETE', url, headers=self.auth)
+        url = self._format("application")
+        return requester.call("DELETE", url, headers=self.auth)
 
     def vehicles(self, **params):
         """ Sends a request to /vehicles
@@ -107,8 +105,8 @@ class Api(object):
             Response: response from the request to the Smartcar API
 
         """
-        url = '{}/{}'.format(const.API_URL, 'vehicles')
-        return requester.call('GET', url, headers=self.auth, params=params)
+        url = "{}/{}".format(const.API_URL, "vehicles")
+        return requester.call("GET", url, headers=self.auth, params=params)
 
     def user(self, **params):
         """ Sends a request to /user
@@ -120,5 +118,5 @@ class Api(object):
             Response: response from the request to the Smartcar API
 
         """
-        url = '{}/{}'.format(const.API_URL, 'user')
-        return requester.call('GET', url, headers=self.auth, params=params)
+        url = "{}/{}".format(const.API_URL, "user")
+        return requester.call("GET", url, headers=self.auth, params=params)

--- a/smartcar/const.py
+++ b/smartcar/const.py
@@ -1,5 +1,5 @@
-API_VERSION = '1.0'
-API_URL = 'https://api.smartcar.com/v{}'.format(API_VERSION)
-AUTH_URL = 'https://auth.smartcar.com/oauth/token'
-CONNECT_URL = 'https://connect.smartcar.com'
-UNIT_SYSTEM_HEADER = 'sc-unit-system'
+API_VERSION = "1.0"
+API_URL = "https://api.smartcar.com/v{}".format(API_VERSION)
+AUTH_URL = "https://auth.smartcar.com/oauth/token"
+CONNECT_URL = "https://connect.smartcar.com"
+UNIT_SYSTEM_HEADER = "sc-unit-system"

--- a/smartcar/exceptions.py
+++ b/smartcar/exceptions.py
@@ -1,41 +1,59 @@
 class SmartcarException(Exception):
     def __init__(self, response):
         json = response.json()
-        if 'message' in json:
-            self.message = json['message']
-        elif 'error_description' in json:
-            self.message = json['error_description']
+        if "message" in json:
+            self.message = json["message"]
+        elif "error_description" in json:
+            self.message = json["error_description"]
         else:
-            self.message = 'Unknown error'
+            self.message = "Unknown error"
 
     def __str__(self):
         return self.message
 
+
 class ValidationException(SmartcarException):
     pass
+
+
 class AuthenticationException(SmartcarException):
     pass
+
+
 class PermissionException(SmartcarException):
     pass
+
+
 class ResourceNotFoundException(SmartcarException):
     pass
+
+
 class StateException(SmartcarException):
     def __init__(self, response):
         super(StateException, self).__init__(response)
         json = response.json()
-        self.code = json['code']
+        self.code = json["code"]
 
     def __str__(self):
-        return self.code + ': ' + self.message
+        return self.code + ": " + self.message
+
 
 class RateLimitingException(SmartcarException):
     pass
+
+
 class MonthlyLimitExceeded(SmartcarException):
     pass
+
+
 class ServerException(SmartcarException):
     pass
+
+
 class NotCapableException(SmartcarException):
     pass
+
+
 class GatewayTimeoutException(SmartcarException):
     def __init__(self, response):
         self.message = response.text

--- a/smartcar/requester.py
+++ b/smartcar/requester.py
@@ -3,6 +3,7 @@ import requests
 from . import exceptions as E
 from . import __version__
 
+
 def call(method, url, **kwargs):
     """ Attachs the kwargs into the headers, sends the request to the Smartcar API
         and handles all error cases
@@ -16,13 +17,10 @@ def call(method, url, **kwargs):
         dict: response from the request to the Smartcar API
 
     """
-    if 'headers' not in kwargs:
-        kwargs['headers'] = {}
-    kwargs['headers']['User-Agent'] = 'Smartcar/{} ({}; {}) Python v{}'.format(
-        __version__,
-        platform.system(),
-        platform.machine(),
-        platform.python_version()
+    if "headers" not in kwargs:
+        kwargs["headers"] = {}
+    kwargs["headers"]["User-Agent"] = "Smartcar/{} ({}; {}) Python v{}".format(
+        __version__, platform.system(), platform.machine(), platform.python_version()
     )
 
     response = requests.request(method, url, **kwargs)

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -1,17 +1,20 @@
 from . import api, const, requester, vehicle
 import time
 from datetime import datetime, timedelta
+
 try:
     from urllib import urlencode
 except ImportError:
     from urllib.parse import urlencode
 
+
 def set_expiration(access):
     expire_date = datetime.utcnow() + timedelta(seconds=access["expires_in"])
     refresh_expire_date = datetime.utcnow() + timedelta(days=60)
-    access['expiration'] = expire_date
-    access['refresh_expiration'] = refresh_expire_date
+    access["expiration"] = expire_date
+    access["refresh_expiration"] = refresh_expire_date
     return access
+
 
 def is_expired(expiration):
     """ Check if an expiration is expired
@@ -23,6 +26,7 @@ def is_expired(expiration):
         bool: true if expired
     """
     return datetime.utcnow() > expiration
+
 
 def get_vehicle_ids(access_token, limit=10, offset=0):
     """ Get a list of the user's vehicle ids
@@ -39,6 +43,7 @@ def get_vehicle_ids(access_token, limit=10, offset=0):
     """
     return api.Api(access_token).vehicles(limit=limit, offset=offset).json()
 
+
 def get_user_id(access_token):
     """ Retrieve the userId associated with the access_token
 
@@ -49,11 +54,19 @@ def get_user_id(access_token):
         str: userId
 
     """
-    return api.Api(access_token).user().json()['id']
+    return api.Api(access_token).user().json()["id"]
+
 
 class AuthClient(object):
-
-    def __init__(self, client_id, client_secret, redirect_uri, scope=None, test_mode=None, development=None):
+    def __init__(
+        self,
+        client_id,
+        client_secret,
+        redirect_uri,
+        scope=None,
+        test_mode=None,
+        development=None,
+    ):
         """ A client for accessing the Smartcar API
 
         Args:
@@ -72,12 +85,13 @@ class AuthClient(object):
         """
         self.client_id = client_id
         self.client_secret = client_secret
-        self.auth=(client_id, client_secret)
+        self.auth = (client_id, client_secret)
         self.redirect_uri = redirect_uri
         self.scope = scope
 
         if development:
             import warnings
+
             message = """Development flag is deprecated. This is discouraged and will be
                          removed in the next major release. Use testMode instead."""
             warnings.warn(message, DeprecationWarning, stacklevel=2)
@@ -105,30 +119,30 @@ class AuthClient(object):
         """
         base_url = const.CONNECT_URL
 
-        approval_prompt = 'force' if force else 'auto'
+        approval_prompt = "force" if force else "auto"
         query = {
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': approval_prompt,
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "approval_prompt": approval_prompt,
         }
 
         if self.test_mode:
-            query['mode'] = 'test'
+            query["mode"] = "test"
 
         if self.scope:
-            query['scope'] = ' '.join(self.scope)
+            query["scope"] = " ".join(self.scope)
 
         if state:
-            query['state'] = state
-        
+            query["state"] = state
+
         if vehicle_info:
-            valid_parameters = ['make']
+            valid_parameters = ["make"]
             for param in valid_parameters:
                 if param in vehicle_info:
                     query[param] = vehicle_info[param]
 
-        return base_url + '/oauth/authorize?' + urlencode(query)
+        return base_url + "/oauth/authorize?" + urlencode(query)
 
     def exchange_code(self, code):
         """ Exchange an authentication code for an access dictionary
@@ -140,16 +154,15 @@ class AuthClient(object):
             dict: dict containing the access and refresh token
 
         """
-        method = 'POST'
+        method = "POST"
         url = const.AUTH_URL
         data = {
-            'grant_type': 'authorization_code',
-            'code': code,
-            'redirect_uri': self.redirect_uri,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
         }
         response = requester.call(method, url, data=data, auth=self.auth).json()
         return set_expiration(response)
-
 
     def exchange_refresh_token(self, refresh_token):
         """ Exchange a refresh token for a new access dictionary
@@ -162,12 +175,9 @@ class AuthClient(object):
             dict: dict containing access and refresh token
 
         """
-        method = 'POST'
+        method = "POST"
         url = const.AUTH_URL
-        data = {
-            'grant_type': 'refresh_token',
-            'refresh_token': refresh_token
-        }
+        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
         response = requester.call(method, url, data=data, auth=self.auth).json()
         return set_expiration(response)
 
@@ -182,11 +192,8 @@ class AuthClient(object):
             boolean: true if the vehicle is compatible
 
         """
-        method = 'GET'
-        url = const.API_URL + '/compatibility'
-        query = {
-            'vin': vin,
-            'scope': " ".join(scope)
-        }
+        method = "GET"
+        url = const.API_URL + "/compatibility"
+        query = {"vin": vin, "scope": " ".join(scope)}
         response = requester.call(method, url, params=query, auth=self.auth).json()
-        return response['compatible']
+        return response["compatible"]

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -1,9 +1,9 @@
 import dateutil.parser
 from .api import Api
 
-class Vehicle(object):
 
-    def __init__(self, vehicle_id, access_token, unit_system='metric'):
+class Vehicle(object):
+    def __init__(self, vehicle_id, access_token, unit_system="metric"):
         """ Initializes a new Vehicle to use for making requests to the Smartcar API.
 
         Args:
@@ -16,7 +16,7 @@ class Vehicle(object):
         self.vehicle_id = vehicle_id
         self.access_token = access_token
         self.api = Api(access_token, vehicle_id)
-        self.api.set_unit_system('metric' if unit_system == 'metric' else 'imperial')
+        self.api.set_unit_system("metric" if unit_system == "metric" else "imperial")
 
     def set_unit_system(self, unit_system):
         """ Update the unit system to use in requests to the Smartcar API.
@@ -25,7 +25,7 @@ class Vehicle(object):
             unit_system (str): the unit system to use (metric/imperial)
 
         """
-        if unit_system not in ('metric','imperial'):
+        if unit_system not in ("metric", "imperial"):
             raise ValueError("unit must be either metric or imperial")
         else:
             self.api.set_unit_system(unit_system)
@@ -37,7 +37,7 @@ class Vehicle(object):
             dict: vehicle's info
 
         """
-        response = self.api.get('')
+        response = self.api.get("")
 
         return response.json()
 
@@ -47,9 +47,9 @@ class Vehicle(object):
         Returns:
             str: vehicle's vin
         """
-        response = self.api.get('vin')
+        response = self.api.get("vin")
 
-        return response.json()['vin']
+        return response.json()["vin"]
 
     def permissions(self):
         """ GET Vehicle.permissions
@@ -59,10 +59,10 @@ class Vehicle(object):
         """
         response = self.api.permissions()
 
-        return response.json()['permissions']
-      
+        return response.json()["permissions"]
+
     def has_permissions(self, permissions):
-      """ Checks if vehicle has specified permission(s).
+        """ Checks if vehicle has specified permission(s).
 
         Args:
             permissions (str or list of str): Permission(s) to check
@@ -70,18 +70,21 @@ class Vehicle(object):
         Returns:
             boolean: Whether the vehicle has the specified permission(s)
       """
-      vehicle_permissions = self.permissions()
-      prefix = "required:"
-      
-      if isinstance(permissions, list):
-        contained = [permission.replace(prefix, '', 1) in vehicle_permissions for permission in permissions]
-        
-        if False in contained:
-          return False
+        vehicle_permissions = self.permissions()
+        prefix = "required:"
+
+        if isinstance(permissions, list):
+            contained = [
+                permission.replace(prefix, "", 1) in vehicle_permissions
+                for permission in permissions
+            ]
+
+            if False in contained:
+                return False
+            else:
+                return True
         else:
-          return True
-      else:
-        return permissions.replace(prefix, '', 1) in vehicle_permissions
+            return permissions.replace(prefix, "", 1) in vehicle_permissions
 
     def disconnect(self):
         """ Disconnect this vehicle from the connected application.
@@ -100,12 +103,12 @@ class Vehicle(object):
             dict: vehicle's odometer
 
         """
-        response = self.api.get('odometer')
+        response = self.api.get("odometer")
 
         return {
-            'data': response.json(),
-            'unit_system': response.headers['sc-unit-system'],
-            'age': dateutil.parser.parse(response.headers['sc-data-age']),
+            "data": response.json(),
+            "unit_system": response.headers["sc-unit-system"],
+            "age": dateutil.parser.parse(response.headers["sc-data-age"]),
         }
 
     def location(self):
@@ -115,11 +118,11 @@ class Vehicle(object):
             dict: vehicle's location
 
         """
-        response = self.api.get('location')
+        response = self.api.get("location")
 
         return {
-            'data': response.json(),
-            'age': dateutil.parser.parse(response.headers['sc-data-age']),
+            "data": response.json(),
+            "age": dateutil.parser.parse(response.headers["sc-data-age"]),
         }
 
     def unlock(self):
@@ -132,10 +135,8 @@ class Vehicle(object):
             SmartcarException
 
         """
-        response = self.api.action('security', 'UNLOCK')
-        return {
-            'status': response.json()['status']
-        }
+        response = self.api.action("security", "UNLOCK")
+        return {"status": response.json()["status"]}
 
     def lock(self):
         """ POST Vehicle.lock
@@ -146,7 +147,5 @@ class Vehicle(object):
         Raises: 
             SmartcarException
         """
-        response = self.api.action('security', 'LOCK')
-        return { 
-            'status': response.json()['status']
-        }
+        response = self.api.action("security", "LOCK")
+        return {"status": response.json()["status"]}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,15 @@
 from smartcar import api
 import unittest
 
+
 class TestAPI(unittest.TestCase):
     def test_format_default(self):
-        a = api.Api('db848eec-6395-11e8-8b72-3b60222a171d', 'fc93a23a-6395-11e8-808d-7b9ff2b247b1')
-        url = a._format('odometer')
-        self.assertEqual(url, 'https://api.smartcar.com/v1.0/vehicles/fc93a23a-6395-11e8-808d-7b9ff2b247b1/odometer')
+        a = api.Api(
+            "db848eec-6395-11e8-8b72-3b60222a171d",
+            "fc93a23a-6395-11e8-808d-7b9ff2b247b1",
+        )
+        url = a._format("odometer")
+        self.assertEqual(
+            url,
+            "https://api.smartcar.com/v1.0/vehicles/fc93a23a-6395-11e8-808d-7b9ff2b247b1/odometer",
+        )

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -3,48 +3,50 @@ import responses
 import requests
 import smartcar
 
+
 class TestRequester(unittest.TestCase):
-    EXPECTED = 'expected'
-    URL = 'http://fake.url'
+    EXPECTED = "expected"
+    URL = "http://fake.url"
 
     def queue(self, status_code, **kwargs):
         """ queue up a fake response with the specified status code """
         if not kwargs:
-            json = { 'message': self.EXPECTED }
+            json = {"message": self.EXPECTED}
         else:
             json = kwargs
 
-        responses.add('GET', self.URL, status=status_code, json=json)
+        responses.add("GET", self.URL, status=status_code, json=json)
 
     def check(self, exception):
 
-        self.assertRaisesRegexp(exception, self.EXPECTED,
-            smartcar.requester.call, 'GET', self.URL)
+        self.assertRaisesRegexp(
+            exception, self.EXPECTED, smartcar.requester.call, "GET", self.URL
+        )
 
     @responses.activate
     def test_user_agent(self):
         self.queue(200)
-        smartcar.requester.call('GET', self.URL)
+        smartcar.requester.call("GET", self.URL)
         self.assertRegexpMatches(
-            responses.calls[0].request.headers['User-Agent'],
-            r'^Smartcar\/(\d+\.\d+\.\d+) \((\w+); (\w+)\) Python v(\d+\.\d+\.\d+)$'
+            responses.calls[0].request.headers["User-Agent"],
+            r"^Smartcar\/(\d+\.\d+\.\d+) \((\w+); (\w+)\) Python v(\d+\.\d+\.\d+)$",
         )
 
     @responses.activate
     def test_oauth_error(self):
-        self.queue(401, error_description='unauthorized')
+        self.queue(401, error_description="unauthorized")
         try:
-            smartcar.requester.call('GET', self.URL)
+            smartcar.requester.call("GET", self.URL)
         except smartcar.AuthenticationException as err:
-            self.assertEqual(err.message, 'unauthorized')
+            self.assertEqual(err.message, "unauthorized")
 
     @responses.activate
     def test_unknown_error(self):
-        self.queue(401, unknown_field='unknown error')
+        self.queue(401, unknown_field="unknown error")
         try:
-            smartcar.requester.call('GET', self.URL)
+            smartcar.requester.call("GET", self.URL)
         except smartcar.AuthenticationException as err:
-            self.assertEqual(err.message, 'Unknown error')
+            self.assertEqual(err.message, "Unknown error")
 
     @responses.activate
     def test_400(self):
@@ -69,10 +71,10 @@ class TestRequester(unittest.TestCase):
     @responses.activate
     def test_409(self):
         message = "Vehicle State Error"
-        code='VS_OO1'
+        code = "VS_OO1"
         self.queue(409, message=message, code=code)
         try:
-            smartcar.requester.call('GET', self.URL)
+            smartcar.requester.call("GET", self.URL)
         except smartcar.StateException as err:
             self.assertEqual(err.message, message)
             self.assertEqual(err.code, code)
@@ -99,11 +101,11 @@ class TestRequester(unittest.TestCase):
 
     @responses.activate
     def test_504(self):
-        responses.add('GET', self.URL, status=504, body=self.EXPECTED)
+        responses.add("GET", self.URL, status=504, body=self.EXPECTED)
         self.check(smartcar.GatewayTimeoutException)
 
     @responses.activate
     def test_other(self):
         self.queue(503)
         with self.assertRaises(requests.exceptions.HTTPError):
-            smartcar.requester.call('GET', self.URL)
+            smartcar.requester.call("GET", self.URL)

--- a/tests/test_smartcar.py
+++ b/tests/test_smartcar.py
@@ -4,11 +4,13 @@ import smartcar
 import base64
 import time
 from datetime import datetime, timedelta
+
 try:
     from urllib import urlencode
     from urlparse import parse_qs
 except ImportError:
     from urllib.parse import urlencode, parse_qs
+
 
 def assertDeepEquals(self, dict1, dict2):
     self.assertEqual(len(dict2), len(dict1))
@@ -16,113 +18,140 @@ def assertDeepEquals(self, dict1, dict2):
     for param in dict1:
         self.assertEqual(dict2[param], dict1[param])
 
+
 def basic_auth(id, secret):
-    auth_pair = id + ':' + secret
-    return 'Basic {}'.format(
-        base64.b64encode(auth_pair.encode('utf-8')).decode('utf-8')
+    auth_pair = id + ":" + secret
+    return "Basic {}".format(
+        base64.b64encode(auth_pair.encode("utf-8")).decode("utf-8")
     )
+
+
 def request():
     return responses.calls[0].request
 
+
 class TestSmartcar(unittest.TestCase):
     def setUp(self):
-        self.client_id = 'client-id'
-        self.client_secret = 'client-secret'
-        self.redirect_uri = 'https://redirect.uri'
-        self.scope = ['a', 'b', 'c']
-        self.client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, True)
+        self.client_id = "client-id"
+        self.client_secret = "client-secret"
+        self.redirect_uri = "https://redirect.uri"
+        self.scope = ["a", "b", "c"]
+        self.client = smartcar.AuthClient(
+            self.client_id, self.client_secret, self.redirect_uri, self.scope, True
+        )
         self.maxDiff = None
         self.basic_auth = basic_auth(self.client_id, self.client_secret)
-        self.expected = {'key': 'value', 'expires_in':7200}
+        self.expected = {"key": "value", "expires_in": 7200}
 
     def test_is_expired(self):
-        access = {'expires_in': 7200}
+        access = {"expires_in": 7200}
 
         now = datetime.utcnow()
-        two_hours_from_now = (datetime.utcnow() + timedelta(hours=2.5))
+        two_hours_from_now = datetime.utcnow() + timedelta(hours=2.5)
 
-        access['expiration'] = (datetime.utcnow() + timedelta(seconds=access['expires_in']))
-        self.assertTrue(now <= access['expiration'] < two_hours_from_now)
+        access["expiration"] = datetime.utcnow() + timedelta(
+            seconds=access["expires_in"]
+        )
+        self.assertTrue(now <= access["expiration"] < two_hours_from_now)
 
-        self.assertFalse(smartcar.is_expired(access['expiration']))
+        self.assertFalse(smartcar.is_expired(access["expiration"]))
 
-        access['expiration'] = (datetime.utcnow() - timedelta(hours=2.1))
+        access["expiration"] = datetime.utcnow() - timedelta(hours=2.1)
 
-        self.assertTrue(smartcar.is_expired(access['expiration']))
+        self.assertTrue(smartcar.is_expired(access["expiration"]))
 
     def test_get_auth_url(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        client = smartcar.AuthClient(
+            self.client_id, self.client_secret, self.redirect_uri, self.scope
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
         assertDeepEquals(self, expected_params, actual_params)
 
     def test_get_auth_url_test_mode_true(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, test_mode=True)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'mode': 'test',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        client = smartcar.AuthClient(
+            self.client_id,
+            self.client_secret,
+            self.redirect_uri,
+            self.scope,
+            test_mode=True,
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "mode": "test",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
         assertDeepEquals(self, expected_params, actual_params)
 
     def test_get_auth_url_test_mode_no_keyword_true(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, True)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'mode': 'test',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        client = smartcar.AuthClient(
+            self.client_id, self.client_secret, self.redirect_uri, self.scope, True
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "mode": "test",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
         assertDeepEquals(self, expected_params, actual_params)
 
     def test_get_auth_url_test_mode_false(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, test_mode=False)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
+        client = smartcar.AuthClient(
+            self.client_id,
+            self.client_secret,
+            self.redirect_uri,
+            self.scope,
+            test_mode=False,
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
 
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
@@ -130,66 +159,85 @@ class TestSmartcar(unittest.TestCase):
         assertDeepEquals(self, expected_params, actual_params)
 
     def test_get_auth_url_development_true(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, development=True)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'mode': 'test',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        client = smartcar.AuthClient(
+            self.client_id,
+            self.client_secret,
+            self.redirect_uri,
+            self.scope,
+            development=True,
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "mode": "test",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
         assertDeepEquals(self, expected_params, actual_params)
 
     def test_get_auth_url_development_false(self):
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, development=False)
-        actual = client.get_auth_url(force=True, state='stuff')
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'scope': ' '.join(self.scope),
-            'state': 'stuff'
-        })
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        client = smartcar.AuthClient(
+            self.client_id,
+            self.client_secret,
+            self.redirect_uri,
+            self.scope,
+            development=False,
+        )
+        actual = client.get_auth_url(force=True, state="stuff")
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "scope": " ".join(self.scope),
+                "state": "stuff",
+            }
+        )
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
         assertDeepEquals(self, expected_params, actual_params)
-    
+
     def test_get_auth_url_vehicle_info_dictionary(self):
-        info = {
-            'make': 'TESLA'
-        }
+        info = {"make": "TESLA"}
 
-        client = smartcar.AuthClient(self.client_id, self.client_secret,
-                self.redirect_uri, self.scope, development=False)
+        client = smartcar.AuthClient(
+            self.client_id,
+            self.client_secret,
+            self.redirect_uri,
+            self.scope,
+            development=False,
+        )
 
-        actual = client.get_auth_url(force=True, state='stuff', vehicle_info=info)
+        actual = client.get_auth_url(force=True, state="stuff", vehicle_info=info)
 
-        query = urlencode({
-            'response_type': 'code',
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'approval_prompt': 'force',
-            'state': 'stuff',
-            'scope': ' '.join(self.scope),
-            'make': 'TESLA'
-        })
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "approval_prompt": "force",
+                "state": "stuff",
+                "scope": " ".join(self.scope),
+                "make": "TESLA",
+            }
+        )
 
-        expected = smartcar.const.CONNECT_URL + '/oauth/authorize?' + query
-        
+        expected = smartcar.const.CONNECT_URL + "/oauth/authorize?" + query
+
         expected_params = parse_qs(expected)
         actual_params = parse_qs(actual)
 
@@ -198,64 +246,68 @@ class TestSmartcar(unittest.TestCase):
     @responses.activate
     def test_exchange_code(self):
         body = {
-            'grant_type': 'authorization_code',
-            'code': 'code',
-            'redirect_uri': self.redirect_uri
+            "grant_type": "authorization_code",
+            "code": "code",
+            "redirect_uri": self.redirect_uri,
         }
-        responses.add('POST', smartcar.const.AUTH_URL, json=self.expected)
-        actual = self.client.exchange_code('code')
-        self.assertIn('key', actual)
-        self.assertTrue(actual['expiration'] > datetime.utcnow())
-        self.assertTrue(actual['refresh_expiration'] > datetime.utcnow())
-        self.assertEqual(request().headers['Authorization'], self.basic_auth)
-        self.assertEqual(request().headers['Content-Type'], 'application/x-www-form-urlencoded')
+        responses.add("POST", smartcar.const.AUTH_URL, json=self.expected)
+        actual = self.client.exchange_code("code")
+        self.assertIn("key", actual)
+        self.assertTrue(actual["expiration"] > datetime.utcnow())
+        self.assertTrue(actual["refresh_expiration"] > datetime.utcnow())
+        self.assertEqual(request().headers["Authorization"], self.basic_auth)
+        self.assertEqual(
+            request().headers["Content-Type"], "application/x-www-form-urlencoded"
+        )
         self.assertEqual(request().body, urlencode(body))
 
     @responses.activate
     def test_exchange_token(self):
-        body = {
-            'grant_type': 'refresh_token',
-            'refresh_token': 'refresh_token'
-        }
-        responses.add('POST', smartcar.const.AUTH_URL, json=self.expected)
-        actual = self.client.exchange_refresh_token('refresh_token')
-        self.assertIn('key', actual)
-        self.assertTrue(actual['expiration'] > datetime.utcnow())
-        self.assertTrue(actual['refresh_expiration'] > datetime.utcnow())
-        self.assertEqual(request().headers['Authorization'], self.basic_auth)
-        self.assertEqual(request().headers['Content-Type'], 'application/x-www-form-urlencoded')
+        body = {"grant_type": "refresh_token", "refresh_token": "refresh_token"}
+        responses.add("POST", smartcar.const.AUTH_URL, json=self.expected)
+        actual = self.client.exchange_refresh_token("refresh_token")
+        self.assertIn("key", actual)
+        self.assertTrue(actual["expiration"] > datetime.utcnow())
+        self.assertTrue(actual["refresh_expiration"] > datetime.utcnow())
+        self.assertEqual(request().headers["Authorization"], self.basic_auth)
+        self.assertEqual(
+            request().headers["Content-Type"], "application/x-www-form-urlencoded"
+        )
         self.assertEqual(request().body, urlencode(body))
 
     @responses.activate
     def test_is_compatible(self):
-        fake_vin = 'vin'
-        scope = ['read_odometer', 'read_location']
+        fake_vin = "vin"
+        scope = ["read_odometer", "read_location"]
 
-        query = { 'vin': fake_vin, 'scope': 'read_odometer read_location' }
-        responses.add('GET', smartcar.const.API_URL + '/compatibility?' + urlencode(query), json={
-            'compatible': True
-        }, match_querystring=True)
+        query = {"vin": fake_vin, "scope": "read_odometer read_location"}
+        responses.add(
+            "GET",
+            smartcar.const.API_URL + "/compatibility?" + urlencode(query),
+            json={"compatible": True},
+            match_querystring=True,
+        )
         actual = self.client.is_compatible(fake_vin, scope)
         self.assertTrue(actual)
 
     @responses.activate
     def test_get_vehicle_ids(self):
-        query = { 'limit': 11, 'offset': 1 }
-        access_token = 'access_token'
-        url = smartcar.const.API_URL + '/vehicles?' + urlencode(query)
-        responses.add('GET', url, json=self.expected, match_querystring=True)
-        actual = smartcar.get_vehicle_ids(access_token, limit=query['limit'], offset=query['offset'])
+        query = {"limit": 11, "offset": 1}
+        access_token = "access_token"
+        url = smartcar.const.API_URL + "/vehicles?" + urlencode(query)
+        responses.add("GET", url, json=self.expected, match_querystring=True)
+        actual = smartcar.get_vehicle_ids(
+            access_token, limit=query["limit"], offset=query["offset"]
+        )
         self.assertEqual(actual, self.expected)
-        self.assertEqual(request().headers['Authorization'], 'Bearer ' + access_token)
+        self.assertEqual(request().headers["Authorization"], "Bearer " + access_token)
 
     @responses.activate
     def test_get_user_id(self):
-        access_token = 'access_token'
-        data = {
-            'id': 'user_id',
-        }
-        url = smartcar.const.API_URL + '/user'
-        responses.add('GET', url, json=data)
+        access_token = "access_token"
+        data = {"id": "user_id"}
+        url = smartcar.const.API_URL + "/user"
+        responses.add("GET", url, json=data)
         actual = smartcar.get_user_id(access_token)
-        self.assertEqual(actual, data['id'])
-        self.assertEqual(request().headers['Authorization'], 'Bearer ' + access_token)
+        self.assertEqual(actual, data["id"])
+        self.assertEqual(request().headers["Authorization"], "Bearer " + access_token)

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -6,30 +6,28 @@ import json
 
 import dateutil.parser
 
+
 class TestVehicle(unittest.TestCase):
     def setUp(self):
-        self.access_token = 'access_token'
-        self.vehicle_id = 'vehicle_id'
+        self.access_token = "access_token"
+        self.vehicle_id = "vehicle_id"
         self.vehicle = smartcar.Vehicle(self.vehicle_id, self.access_token)
-        self.auth = 'Bearer ' + self.access_token
+        self.auth = "Bearer " + self.access_token
 
     def queue(self, method, endpoint, body=None, query=None, headers=None):
         """ queue a mock response """
-        url = '/'.join((smartcar.const.API_URL, 'vehicles', self.vehicle_id, endpoint))
+        url = "/".join((smartcar.const.API_URL, "vehicles", self.vehicle_id, endpoint))
         if query:
-            query_string = '&'.join(
-                k + '=' + str(v) for k,v in query.items()
-            )
-            url += '?' + query_string
+            query_string = "&".join(k + "=" + str(v) for k, v in query.items())
+            url += "?" + query_string
         if not body:
             body = {}
         if not headers:
             headers = {}
 
-        responses.add(method, url,
-                json=body,
-                match_querystring=bool(query),
-                headers=headers)
+        responses.add(
+            method, url, json=body, match_querystring=bool(query), headers=headers
+        )
 
     def check(self, actual, **kwargs):
         """
@@ -40,60 +38,60 @@ class TestVehicle(unittest.TestCase):
         self.assertEqual(len(responses.calls), 1)
 
         request = responses.calls[0].request
-        request_auth = request.headers['Authorization']
+        request_auth = request.headers["Authorization"]
         self.assertEqual(request_auth, self.auth)
 
         if kwargs:
-            request_json = json.loads(request.body.decode('utf-8'))
-            for k,v in kwargs.items():
-               self.assertEqual(request_json[k], v)
+            request_json = json.loads(request.body.decode("utf-8"))
+            for k, v in kwargs.items():
+                self.assertEqual(request_json[k], v)
 
     @responses.activate
     def test_unit_system(self):
-        age = '2018-04-30T22:28:52+00:00'
-        self.queue('GET', 'odometer', headers={
-            'sc-unit-system': 'metric',
-            'sc-data-age': age,
-        })
+        age = "2018-04-30T22:28:52+00:00"
+        self.queue(
+            "GET", "odometer", headers={"sc-unit-system": "metric", "sc-data-age": age}
+        )
         self.vehicle.odometer()
         headers = responses.calls[0].request.headers
-        unit_system = headers['sc-unit-system']
-        self.assertEqual(unit_system, 'metric')
+        unit_system = headers["sc-unit-system"]
+        self.assertEqual(unit_system, "metric")
 
-        self.queue('GET', 'odometer', headers={
-            'sc-unit-system': 'imperial',
-            'sc-data-age': age,
-        })
-        self.vehicle.set_unit_system('imperial')
+        self.queue(
+            "GET",
+            "odometer",
+            headers={"sc-unit-system": "imperial", "sc-data-age": age},
+        )
+        self.vehicle.set_unit_system("imperial")
         self.vehicle.odometer()
         headers = responses.calls[1].request.headers
-        unit_system = headers['sc-unit-system']
-        self.assertEqual(unit_system, 'imperial')
+        unit_system = headers["sc-unit-system"]
+        self.assertEqual(unit_system, "imperial")
 
     @responses.activate
     def test_permission(self):
-        data = {
-            "permissions": ["read_odometer"]
-        }
+        data = {"permissions": ["read_odometer"]}
 
-        self.queue('GET', 'permissions', data)
+        self.queue("GET", "permissions", data)
         response = self.vehicle.permissions()
 
         self.check(response)
-        self.assertEqual(response, data['permissions'])
-        
+        self.assertEqual(response, data["permissions"])
+
     @responses.activate
     def test_has_permissions(self):
-        data = {
-            "permissions": ["read_odometer" , "read_vehicle_info"]
-        }
+        data = {"permissions": ["read_odometer", "read_vehicle_info"]}
 
-        self.queue('GET', 'permissions', data)
+        self.queue("GET", "permissions", data)
         single_response = self.vehicle.has_permissions("read_odometer")
         required_response = self.vehicle.has_permissions("required:read_odometer")
-        multi_response = self.vehicle.has_permissions(["read_odometer", "required:read_vehicle_info"])
+        multi_response = self.vehicle.has_permissions(
+            ["read_odometer", "required:read_vehicle_info"]
+        )
         false_response = self.vehicle.has_permissions("read_location")
-        false_multi_response = self.vehicle.has_permissions(["read_odometer", "read_location"])
+        false_multi_response = self.vehicle.has_permissions(
+            ["read_odometer", "read_location"]
+        )
 
         self.assertTrue(single_response)
         self.assertTrue(required_response)
@@ -104,13 +102,13 @@ class TestVehicle(unittest.TestCase):
     @responses.activate
     def test_info(self):
         data = {
-          "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
-          "make": "TESLA",
-          "model": "Model S",
-          "year": 2014
+            "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
+            "make": "TESLA",
+            "model": "Model S",
+            "year": 2014,
         }
 
-        self.queue('GET', '', body=data)
+        self.queue("GET", "", body=data)
         response = self.vehicle.info()
 
         self.check(response)
@@ -118,69 +116,62 @@ class TestVehicle(unittest.TestCase):
 
     @responses.activate
     def test_location(self):
-        data = {
-            'latitude': 37.4292,
-            'longitude': 122.1381
-        }
+        data = {"latitude": 37.4292, "longitude": 122.1381}
 
-        age = '2018-04-30T22:28:52+00:00'
-        self.queue('GET', 'location', body=data, headers={ 'sc-data-age': age })
+        age = "2018-04-30T22:28:52+00:00"
+        self.queue("GET", "location", body=data, headers={"sc-data-age": age})
         response = self.vehicle.location()
 
         self.check(response)
-        self.assertEqual(response['data'], data)
-        self.assertEqual(response['age'], dateutil.parser.parse(age))
+        self.assertEqual(response["data"], data)
+        self.assertEqual(response["age"], dateutil.parser.parse(age))
 
     @responses.activate
     def test_odometer(self):
-        data = {
-            'odometer': 1234
-        }
+        data = {"odometer": 1234}
 
-        age = '2018-04-30T22:28:52+00:00'
-        self.queue('GET', 'odometer', body=data, headers={
-            'sc-unit-system': 'metric',
-            'sc-data-age': age,
-        })
+        age = "2018-04-30T22:28:52+00:00"
+        self.queue(
+            "GET",
+            "odometer",
+            body=data,
+            headers={"sc-unit-system": "metric", "sc-data-age": age},
+        )
         response = self.vehicle.odometer()
 
         self.check(response)
-        self.assertEqual(response['data'], data)
-        self.assertEqual(response['unit_system'], 'metric')
-        self.assertEqual(response['age'], dateutil.parser.parse(age))
+        self.assertEqual(response["data"], data)
+        self.assertEqual(response["unit_system"], "metric")
+        self.assertEqual(response["age"], dateutil.parser.parse(age))
 
     @responses.activate
     def test_vin(self):
-        data = { 'vin': 'fakeVin'}
-        self.queue('GET', 'vin', body=data)
+        data = {"vin": "fakeVin"}
+        self.queue("GET", "vin", body=data)
 
         response = self.vehicle.vin()
         self.check(response)
-        self.assertEqual(response, data['vin'])
+        self.assertEqual(response, data["vin"])
 
     @responses.activate
     def test_disconnect(self):
-        self.queue('DELETE', 'application')
+        self.queue("DELETE", "application")
         self.check(self.vehicle.disconnect())
 
     @responses.activate
     def test_lock(self):
-        data = {
-            'status': 'success'
-        }
-        self.queue('POST', 'security', body=data)
-        
+        data = {"status": "success"}
+        self.queue("POST", "security", body=data)
+
         response = self.vehicle.lock()
-        self.check(response, action='LOCK')
-        self.assertEqual(response['status'], data['status'])
+        self.check(response, action="LOCK")
+        self.assertEqual(response["status"], data["status"])
 
     @responses.activate
     def test_unlock(self):
-        data = {
-            'status': 'success'
-        }
-        self.queue('POST', 'security', body=data)
-        
+        data = {"status": "success"}
+        self.queue("POST", "security", body=data)
+
         response = self.vehicle.unlock()
-        self.check(response, action='UNLOCK')
-        self.assertEqual(response['status'], data['status'])
+        self.check(response, action="UNLOCK")
+        self.assertEqual(response["status"], data["status"])

--- a/tests/tests_e2e/test_base.py
+++ b/tests/tests_e2e/test_base.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import unittest
 import uuid
+
 try:
     import urlparse
 except BaseException:
@@ -17,7 +18,6 @@ import smartcar
 
 
 class TestBase(unittest.TestCase):
-
     @classmethod
     @retry(wait_fixed=1000, stop_max_attempt_number=5)
     def setUpClass(cls):
@@ -25,53 +25,53 @@ class TestBase(unittest.TestCase):
             driver.get(auth_url)
 
             tesla_button = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((
-                    By.CSS_SELECTOR,
-                    "button[data-make='TESLA']")))
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, "button[data-make='TESLA']")
+                )
+            )
             tesla_button.click()
 
             username = uuid.uuid4()
-            username = str(username) + '@mock.com'
+            username = str(username) + "@mock.com"
 
             sign_in_button = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, 'sign-in-button')))
-            driver.find_element_by_id('username').send_keys(username)
-            driver.find_element_by_id('password').send_keys('password')
+                EC.presence_of_element_located((By.ID, "sign-in-button"))
+            )
+            driver.find_element_by_id("username").send_keys(username)
+            driver.find_element_by_id("password").send_keys("password")
             sign_in_button.click()
 
             permissions_approval_button = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, 'approval-button')))
+                EC.presence_of_element_located((By.ID, "approval-button"))
+            )
             permissions_approval_button.click()
 
             url = driver.current_url
             parsed_url = urlparse.urlparse(url)
-            return urlparse.parse_qs(parsed_url.query)['code'][0]
+            return urlparse.parse_qs(parsed_url.query)["code"][0]
 
-        client_id = os.environ['INTEGRATION_CLIENT_ID']
-        client_secret = os.environ['INTEGRATION_CLIENT_SECRET']
-        redirect_uri = 'https://example.com/auth'
+        client_id = os.environ["INTEGRATION_CLIENT_ID"]
+        client_secret = os.environ["INTEGRATION_CLIENT_SECRET"]
+        redirect_uri = "https://example.com/auth"
         scope = [
-            'control_security:unlock',
-            'control_security:lock',
-            'read_vehicle_info',
-            'read_vin',
-            'read_location',
-            'read_odometer'
+            "control_security:unlock",
+            "control_security:lock",
+            "read_vehicle_info",
+            "read_vin",
+            "read_location",
+            "read_odometer",
         ]
         test_mode = True
 
         cls.client = smartcar.AuthClient(
-            client_id,
-            client_secret,
-            redirect_uri,
-            scope,
-            test_mode
+            client_id, client_secret, redirect_uri, scope, test_mode
         )
 
         cls.driver = webdriver.Remote(
-            command_executor='http://127.0.0.1:4444/wd/hub',
+            command_executor="http://127.0.0.1:4444/wd/hub",
             desired_capabilities=DesiredCapabilities.CHROME,
-            keep_alive=True)
+            keep_alive=True,
+        )
 
         auth_url = cls.client.get_auth_url()
 

--- a/tests/tests_e2e/test_smartcar.py
+++ b/tests/tests_e2e/test_smartcar.py
@@ -4,29 +4,29 @@ import unittest
 
 
 class TestSmartcarAuthE2E(TestBase):
-
     def test_exchange_code(self):
         def assert_access_object(access_object):
             self.assertIsNotNone(access_object)
-            self.assertIn('access_token', access_object)
-            self.assertIn('token_type', access_object)
-            self.assertIn('refresh_token', access_object)
-            self.assertIn('expires_in', access_object)
-            self.assertIn('expiration', access_object)
-            self.assertIn('refresh_expiration', access_object)
+            self.assertIn("access_token", access_object)
+            self.assertIn("token_type", access_object)
+            self.assertIn("refresh_token", access_object)
+            self.assertIn("expires_in", access_object)
+            self.assertIn("expiration", access_object)
+            self.assertIn("refresh_expiration", access_object)
 
         access_object = self.client.exchange_code(self.code)
         assert_access_object(access_object)
 
         new_access_object = self.client.exchange_refresh_token(
-            access_object['refresh_token'])
+            access_object["refresh_token"]
+        )
         assert_access_object(new_access_object)
 
     def test_is_compatible(self):
-        teslaVin = '5YJXCDE22HF068739'
-        audiVin = 'WAUAFAFL1GN014882'
+        teslaVin = "5YJXCDE22HF068739"
+        audiVin = "WAUAFAFL1GN014882"
 
-        scopes = ['read_odometer', 'read_location']
+        scopes = ["read_odometer", "read_location"]
 
         teslaComp = self.client.is_compatible(teslaVin, scopes)
         audiComp = self.client.is_compatible(audiVin, scopes)
@@ -34,15 +34,15 @@ class TestSmartcarAuthE2E(TestBase):
         self.assertTrue(teslaComp)
         self.assertFalse(audiComp)
 
-class TestSmartcarStaticE2E(TestBase):
 
+class TestSmartcarStaticE2E(TestBase):
     @classmethod
     def setUpClass(cls):
         super(TestSmartcarStaticE2E, cls).setUpClass()
 
         access_object = cls.client.exchange_code(cls.code)
 
-        cls.access_token = access_object['access_token']
+        cls.access_token = access_object["access_token"]
 
     def test_get_vehicle_ids(self):
         vehicle_ids = smartcar.get_vehicle_ids(self.access_token)

--- a/tests/tests_e2e/test_vehicle.py
+++ b/tests/tests_e2e/test_vehicle.py
@@ -9,18 +9,15 @@ unittest.TestLoader.sortTestMethodsUsing = lambda _, x, y: (y > x) - (y < x)
 
 
 class TestVehicleE2E(TestBase):
-
     @classmethod
     def setUpClass(cls):
         super(TestVehicleE2E, cls).setUpClass()
 
         access_object = cls.client.exchange_code(cls.code)
 
-        access_token = access_object['access_token']
+        access_token = access_object["access_token"]
         vehicle_ids = smartcar.get_vehicle_ids(access_token)
-        cls.vehicle = smartcar.Vehicle(
-            vehicle_ids['vehicles'][0],
-            access_token)
+        cls.vehicle = smartcar.Vehicle(vehicle_ids["vehicles"][0], access_token)
 
     def test_odometer(self):
         odometer = self.vehicle.odometer()
@@ -40,9 +37,13 @@ class TestVehicleE2E(TestBase):
 
     def test_has_permissions(self):
         single_response = self.vehicle.has_permissions("required:read_odometer")
-        multi_response = self.vehicle.has_permissions(["read_odometer", "required:read_vehicle_info"])
+        multi_response = self.vehicle.has_permissions(
+            ["read_odometer", "required:read_vehicle_info"]
+        )
         false_response = self.vehicle.has_permissions("read_ignition")
-        false_multi_response = self.vehicle.has_permissions(["read_odometer", "read_ignition"])
+        false_multi_response = self.vehicle.has_permissions(
+            ["read_odometer", "read_ignition"]
+        )
 
         self.assertTrue(single_response)
         self.assertTrue(multi_response)


### PR DESCRIPTION
Currently, we don't really have a standard to format our python-sdk.

This PR proposes that we move to the [black](https://github.com/python/black) formatter.

Black is the new "hotness" in the python community, and is being adopted by projects like:

- Django
- Pypi
- SQLAlchemy
- requests
- [more](https://github.com/python/black#used-by)

Black gets rid of a lot of the stupid PEP8 rules like the 79 character line limit, the trailing closing parens, and much more stupid rules.