### PR TITLE
refactor: Clean up SDK, fix typos, match spec

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -405,11 +405,12 @@ Lock the vehicle.
 
 #### Return
 
-| Value           | Type         | Description                                                                           |
-| :-------------- | :----------- | :------------------------------------------------------------------------------------ |
-| `Status`        | NamedTuple   | The returned object with vehicle's "status" after sending a request to lock the doors |
-| `Status.status` | String       | Set to "success" on successful request.                                               |
-| `Status.meta`   | Dictionary\* | Response headers and other information about the response                             |
+| Value            | Type         | Description                                                                         |
+| :--------------- | :----------- | :---------------------------------------------------------------------------------- |
+| `Action`         | NamedTuple   | The returned object with vehicle's status after sending a request to lock the doors |
+| `Action.status`  | String       | Set to "success" on successful request.                                             |
+| `Action.message` | String       | Message of the response.                                                            |
+| `Action.meta`    | Dictionary\* | Response headers and other information about the response                           |
 
 \*`requests.structures.CaseInsensitiveDict`
 
@@ -426,11 +427,12 @@ Unlock the vehicle.
 
 #### Return
 
-| Value           | Type         | Description                                                                             |
-| :-------------- | :----------- | :-------------------------------------------------------------------------------------- |
-| `Status`        | NamedTuple   | The returned object with vehicle's "status" after sending a request to unlock the doors |
-| `Status.status` | String       | Set to "success" on successful request.                                                 |
-| `Status.meta`   | Dictionary\* | Response headers and other information about the response                               |
+| Value            | Type         | Description                                                                           |
+| :--------------- | :----------- | :------------------------------------------------------------------------------------ |
+| `Action`         | NamedTuple   | The returned object with vehicle's status after sending a request to unlock the doors |
+| `Action.status`  | String       | Set to "success" on successful request.                                               |
+| `Action.message` | String       | Message of the response.                                                              |
+| `Action.meta`    | Dictionary\* | Response headers and other information about the response                             |
 
 \*`requests.structures.CaseInsensitiveDict`
 
@@ -446,11 +448,12 @@ Start charging the vehicle.
 
 #### Return
 
-| Value           | Type         | Description                                                                                  |
-| :-------------- | :----------- | :------------------------------------------------------------------------------------------- |
-| `Status`        | NamedTuple   | The returned object with vehicle's "status" after sending a request to start charging the EV |
-| `Status.status` | String       | Set to "success" on successful request.                                                      |
-| `Status.meta`   | Dictionary\* | Response headers and other information about the response                                    |
+| Value            | Type         | Description                                                                                |
+| :--------------- | :----------- | :----------------------------------------------------------------------------------------- |
+| `Action`         | NamedTuple   | The returned object with vehicle's status after sending a request to start charging the EV |
+| `Action.status`  | String       | Set to "success" on successful request.                                                    |
+| `Action.message` | String       | Message of the response.                                                                   |
+| `Action.meta`    | Dictionary\* | Response headers and other information about the response                                  |
 
 \*`requests.structures.CaseInsensitiveDict`
 
@@ -466,11 +469,12 @@ Stop charging the vehicle.
 
 #### Return
 
-| Value           | Type         | Description                                                                                 |
-| :-------------- | :----------- | :------------------------------------------------------------------------------------------ |
-| `Status`        | NamedTuple   | The returned object with vehicle's "status" after sending a request to stop charging the EV |
-| `Status.status` | String       | Set to "success" on successful request.                                                     |
-| `Status.meta`   | Dictionary\* | Response headers and other information about the response                                   |
+| Value            | Type         | Description                                                                               |
+| :--------------- | :----------- | :---------------------------------------------------------------------------------------- |
+| `Action`         | NamedTuple   | The returned object with vehicle's status after sending a request to stop charging the EV |
+| `Action.status`  | String       | Set to "success" on successful request.                                                   |
+| `Action.message` | String       | Message of the response.                                                                  |
+| `Action.meta`    | Dictionary\* | Response headers and other information about the response                                 |
 
 \*`requests.structures.CaseInsensitiveDict`
 
@@ -590,7 +594,7 @@ the [exceptions section](https://github.com/smartcar/python-sdk#handling-excepti
 
 ### `unsubscribe(self, amt, webhook_id)`
 
-Unubscribe vehicle from a Smartcar webhook.
+Unsbscribe vehicle from a Smartcar webhook.
 
 #### Arguments
 

--- a/smartcar/api.py
+++ b/smartcar/api.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import re
+import requests
 
 import smartcar.constants as constants
 import smartcar.requester as requester
@@ -31,7 +32,7 @@ class Smartcar(object):
     # Utility Methods
     # ===========================================
 
-    def get(self, endpoint: str, **params):
+    def get(self, endpoint: str, **params) -> requests.models.Response:
         """
         Sends GET requests to Smartcar API vehicle endpoints.
 
@@ -47,7 +48,7 @@ class Smartcar(object):
         headers[constants.UNIT_SYSTEM_HEADER] = self.unit_system
         return requester.call("GET", url, headers=self.auth, params=params)
 
-    def post(self, endpoint: str, **body):
+    def post(self, endpoint: str, **body) -> requests.models.Response:
         """
         Sends POST requests to Smartcar API
 
@@ -67,7 +68,7 @@ class Smartcar(object):
 
         return requester.call("POST", url, json=json, headers=self.auth)
 
-    def delete(self, endpoint: str):
+    def delete(self, endpoint: str) -> requests.models.Response:
         """
         Sends DELETE Requests to Smartcar API
 
@@ -108,25 +109,27 @@ class Smartcar(object):
     # Methods directly related to vehicle.py
     # ===========================================
 
-    def batch(self, requests: list):
+    def batch(self, request_list: list) -> requests.models.Response:
         """
         Sends POST requests to Smartcar API
 
         Args:
-            requests (object[]) - a list of objects containing a 'path' key
+            request_list (object[]) - a list of objects containing a 'path' key
 
         Returns:
             Response: response from the Smartcar API
         """
         endpoint = "batch"
         url = self._format_vehicle_endpoint(endpoint)
-        json = {"requests": requests}
+        json = {"requests": request_list}
         headers = self.auth
         headers[constants.UNIT_SYSTEM_HEADER] = self.unit_system
 
         return requester.call("POST", url, json=json, headers=headers)
 
-    def unsubscribe_from_webhook(self, amt: str, webhook_id: str):
+    def unsubscribe_from_webhook(
+        self, amt: str, webhook_id: str
+    ) -> requests.models.Response:
         """
         Sends DELETE request to unsubscribe vehicle from webhook.
         Uses a custom header.
@@ -146,7 +149,7 @@ class Smartcar(object):
     # Methods directly related to static.py
     # ===========================================
 
-    def user(self):
+    def user(self) -> requests.models.Response:
         """
         Sends a request to /user
 
@@ -156,7 +159,7 @@ class Smartcar(object):
         url = f"{self.base_url}/user"
         return requester.call("GET", url, headers=self.auth)
 
-    def vehicles(self, **params):
+    def vehicles(self, **params) -> requests.models.Response:
         """
         Sends a request to /vehicles
 
@@ -169,7 +172,7 @@ class Smartcar(object):
         url = f"{self.base_url}/vehicles"
         return requester.call("GET", url, headers=self.auth, params=params)
 
-    def compatibility(self, **params):
+    def compatibility(self, **params) -> requests.models.Response:
         url = f"{constants.API_URL}/v{API_VERSION}/compatibility"
         id_secret = f"{self.client_id}:{self.client_secret}"
         encoded_id_secret = id_secret.encode("ascii")
@@ -186,7 +189,7 @@ class Smartcar(object):
     # Private Methods
     # ===========================================
 
-    def _format_vehicle_endpoint(self, endpoint: str):
+    def _format_vehicle_endpoint(self, endpoint: str) -> str:
         """
         Generates the formatted URL to <base_url>/vehicles/<vehicle_id>/<endpoint>
         These vehicle-related endpoints are widely used to get vehicle information.
@@ -222,6 +225,9 @@ class Smartcar(object):
         self.client_id = os.environ.get(f"{environment}_CLIENT_ID")
         self.client_secret = os.environ.get(f"{environment}_CLIENT_SECRET")
         self.client_redirect_uri = os.environ.get(f"{environment}_REDIRECT_URI")
+
+
+# API-related static methods
 
 
 def set_api_version(version: str) -> None:

--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -57,7 +57,7 @@ class AuthClient(object):
         self.auth = (client_id, client_secret)
         self.test_mode = test_mode
 
-    def get_auth_url(self, scope: List[str], options: dict = None):
+    def get_auth_url(self, scope: List[str], options: dict = None) -> str:
         """
         Generate the Connect URL
 
@@ -197,7 +197,7 @@ class AuthClient(object):
 # Static helpers for AuthClient
 
 
-def _set_expiration(access):
+def _set_expiration(access: dict) -> dict:
     expire_date = datetime.utcnow() + timedelta(seconds=access["expires_in"])
     refresh_expire_date = datetime.utcnow() + timedelta(days=60)
     access["expiration"] = expire_date

--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -115,7 +115,7 @@ class AuthClient(object):
                 single_select = options["single_select"]
 
                 if single_select.get("vin"):
-                    query['single_select"vin'] = single_select["vin"]
+                    query["single_select_vin"] = single_select["vin"]
                     query["single_select"] = True
                 elif single_select.get("enabled"):
                     query["single_select"] = True

--- a/smartcar/exception.py
+++ b/smartcar/exception.py
@@ -59,7 +59,7 @@ def exception_factory(status_code: int, headers: dict, body: str):
             type=response.get("type"),
             description=response.get("description"),
             code=response.get("code"),
-            doc_url=response.get("docUrl"),
+            doc_url=response.get("docURL"),
             resolution=response.get("resolution"),
             detail=response.get("detail"),
         )

--- a/smartcar/static.py
+++ b/smartcar/static.py
@@ -1,4 +1,3 @@
-import re
 import hmac
 import hashlib
 import binascii

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -98,7 +98,7 @@ Fuel = NamedTuple(
 )
 
 TirePressure = NamedTuple(
-    "tirePressure",
+    "TirePressure",
     [
         ("front_left", int),
         ("front_right", int),

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -75,7 +75,7 @@ Vin = NamedTuple("Vin", [("vin", str), ("meta", rs.CaseInsensitiveDict)])
 
 Charge = NamedTuple(
     "Charge",
-    [("is_plugged_in", bool), ("status", str), ("meta", rs.CaseInsensitiveDict)],
+    [("is_plugged_in", bool), ("state", str), ("meta", rs.CaseInsensitiveDict)],
 )
 
 Battery = NamedTuple(
@@ -130,6 +130,10 @@ Attributes = NamedTuple(
         ("year", str),
         ("meta", rs.CaseInsensitiveDict),
     ],
+)
+
+Action = NamedTuple(
+    "Action", [("status", str), ("message", str), ("meta", rs.CaseInsensitiveDict)]
 )
 
 Status = NamedTuple("Status", [("status", str), ("meta", rs.CaseInsensitiveDict)])
@@ -254,8 +258,10 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
         or path == "unlock"
         or path == "start_charge"
         or path == "stop_charge"
-        or path == "disconnect"
     ):
+        return Action(data["status"], data["message"], headers)
+
+    elif path == "disconnect":
         return Status(data["status"], headers)
 
     elif path == "":

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -121,8 +121,8 @@ Location = NamedTuple(
     [("latitude", float), ("longitude", float), ("meta", rs.CaseInsensitiveDict)],
 )
 
-Info = NamedTuple(
-    "Info",
+Attributes = NamedTuple(
+    "Attributes",
     [
         ("id", str),
         ("make", str),
@@ -259,7 +259,7 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
         return Status(data["status"], headers)
 
     elif path == "":
-        return Info(
+        return Attributes(
             data["id"],
             data["make"],
             data["model"],

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -196,12 +196,12 @@ class Vehicle(object):
 
         return ty.select_named_tuple("permissions", response)
 
-    def info(self) -> ty.Info:
+    def attributes(self) -> ty.Attributes:
         """
-        GET Vehicle.info
+        GET Vehicle.attributes
 
         Returns:
-            Info: NamedTuple("Info", [("id", str), ("make", str), ("model", str), ("year", str),
+            Attributes: NamedTuple("Attributes", [("id", str), ("make", str), ("model", str), ("year", str),
             ("meta", CaseInsensitiveDict)])
 
         Raises:

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -66,7 +66,7 @@ class Vehicle(object):
         GET Vehicle.charge
 
         Returns:
-            Charge: NamedTuple("Charge", [("is_plugged_in", bool), ("status", str), ("meta", CaseInsensitiveDict)])
+            Charge: NamedTuple("Charge", [("is_plugged_in", bool), ("state", str), ("meta", CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -219,7 +219,7 @@ class Vehicle(object):
         POST Vehicle.lock
 
         Returns:
-            Status: NamedTuple("Status", [("status", str), ("meta", CaseInsensitiveDict)])
+            Action: NamedTuple("Action", [("status", str), ("message", str), ("meta", rs.CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -232,7 +232,7 @@ class Vehicle(object):
         POST Vehicle.unlock
 
         Returns:
-            Status: NamedTuple("Status", [("status", str), ("meta", CaseInsensitiveDict)])
+            Action: NamedTuple("Action", [("status", str), ("message", str), ("meta", rs.CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -245,7 +245,7 @@ class Vehicle(object):
         POST Vehicle.start_charge
 
         Returns:
-            Status: NamedTuple("Status", [("status", str), ("meta", CaseInsensitiveDict)])
+            Action: NamedTuple("Action", [("status", str), ("message", str), ("meta", rs.CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -258,7 +258,7 @@ class Vehicle(object):
         POST Vehicle.stop_charge
 
         Returns:
-            Status: NamedTuple("Status", [("status", str), ("meta", CaseInsensitiveDict)])
+            Action: NamedTuple("Action", [("status", str), ("message", str), ("meta", rs.CaseInsensitiveDict)])
 
         Raises:
             SmartcarException

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -1,10 +1,10 @@
+from collections import namedtuple
 from typing import List
 import requests.structures as rs
 
 import smartcar.api
 import smartcar.auth_client
 import smartcar.constants as constants
-import smartcar.static as static
 import smartcar.types as ty
 from smartcar.api import Smartcar
 
@@ -36,12 +36,12 @@ class Vehicle(object):
                 if version != smartcar.api.API_VERSION:
                     self.api.base_url = f"{constants.API_URL}/v{version}"
 
-    def set_unit_system(self, unit_system):
+    def set_unit_system(self, unit_system: str) -> None:
         """
         Update the unit system to use in requests to the Smartcar API.
 
         Args:
-            unit_system (str): the unit system to use (metric/imperial)
+            unit_system (str): the unit system to use ("metric" or "imperial")
         """
         if unit_system not in ("metric", "imperial"):
             raise ValueError("unit must be either metric or imperial")
@@ -81,8 +81,7 @@ class Vehicle(object):
         Returns:
             Battery: NamedTuple("Battery", [("percent_remaining", float),
                 ("range", float),
-                ("meta", CaseInsensitiveDict)]
-                )
+                ("meta", CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -109,7 +108,7 @@ class Vehicle(object):
 
         Returns:
             Fuel: NamedTuple("Fuel", [("range", float),
-                ("percentRemaining", float), ("amountRemaining", float), ("meta", CaseInsensitiveDict)])
+                ("percent_remaining", float), ("amount_remaining", float), ("meta", CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -117,12 +116,15 @@ class Vehicle(object):
         response = self.api.get("fuel")
         return ty.select_named_tuple("fuel", response)
 
-    def tire_pressure(self):
+    def tire_pressure(self) -> ty.TirePressure:
         """
         GET Vehicle.tire_pressure
 
         Returns:
-            dict: vehicle's tire pressure status
+            TirePressure: NamedTuple("tirePressure", [
+                ("front_left", int), ("front_right", int), ("back_left", int), ("back_right", int),
+                ("meta", rs.CaseInsensitiveDict)
+                ])
 
         Raises:
             SmartcarException
@@ -199,7 +201,8 @@ class Vehicle(object):
         GET Vehicle.info
 
         Returns:
-            Info: NamedTuple("Info", [("id", str), ("make", str), ("model", str), ("year", str), ("meta", CaseInsensitiveDict)])
+            Info: NamedTuple("Info", [("id", str), ("make", str), ("model", str), ("year", str),
+            ("meta", CaseInsensitiveDict)])
 
         Raises:
             SmartcarException
@@ -263,7 +266,7 @@ class Vehicle(object):
         response = self.api.post("charge", action="STOP")
         return ty.select_named_tuple("stop_charge", response)
 
-    def batch(self, paths: List[str]):
+    def batch(self, paths: List[str]) -> namedtuple:
         """
         POST Vehicle.batch
 
@@ -272,7 +275,8 @@ class Vehicle(object):
             the batch request to
 
         Returns:
-            dict: the HTTP responses, keyed by path
+            namedtuple: the responses from Smartcar API, each attribute is the appropriate
+                NamedTuple for the requested path.
 
         Raises:
             SmartcarException
@@ -346,7 +350,7 @@ class Vehicle(object):
             webhook_id (str)
 
         Returns:
-            Subscribe: NamedTuple("Subscribe", [("webhook_id", str"), ("vehicle_id", str), ("meta", CaseInsensitiveDict)
+            CaseInsensitiveDict: The response headers (i.e. meta) of the request
         """
         response = self.api.unsubscribe_from_webhook(amt, webhook_id)
         return rs.CaseInsensitiveDict(response.headers)

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -25,6 +25,8 @@ HEADLESS = "CI" in os.environ or (
 )
 CLIENT_ID = os.environ["E2E_SMARTCAR_CLIENT_ID"]
 CLIENT_SECRET = os.environ["E2E_SMARTCAR_CLIENT_SECRET"]
+REDIRECT_URI = "https://example.com/auth"
+
 DEFAULT_SCOPE = [
     "required:read_vehicle_info",
     "required:read_location",
@@ -40,9 +42,8 @@ DEFAULT_SCOPE = [
 
 
 def get_auth_client_params():
-    redirect_uri = "https://example.com/auth"
     test_mode = True
-    return [CLIENT_ID, CLIENT_SECRET, redirect_uri, test_mode]
+    return [CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, test_mode]
 
 
 def get_code_from_url(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import tests.auth_helpers as ah
 # Fixtures that can be used throughout the testing suite:
 
 # # Auth Fixtures:
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def client():
     """
     Set up a Smartcar Auth Client with test parameters.
@@ -24,7 +24,7 @@ def client():
     yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def access_object(client):
     """
     Using the client fixture, go through Smartcar connect auth
@@ -42,7 +42,7 @@ def access_object(client):
 
 
 # # Vehicle Fixtures:
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def chevy_volt(access_object):
     """
     Using default access token that has the default scope
@@ -59,7 +59,7 @@ def chevy_volt(access_object):
     return sc.Vehicle(volt_id, access_token)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def vw_egolf(access_object):
     """
     Using a separate instance of smartcar.AuthClient,
@@ -81,7 +81,7 @@ def vw_egolf(access_object):
 
 
 # # API Fixture
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def api_instance(access_object, chevy_volt):
     """
     Using the token from the access_object, instantiate a api.Smartcar

--- a/tests/e2e/test_exception.py
+++ b/tests/e2e/test_exception.py
@@ -1,4 +1,4 @@
-from smartcar import get_user
+from smartcar import get_user, Vehicle
 from smartcar.exception import SmartcarException
 
 
@@ -8,3 +8,14 @@ def test_wrong_access_token():
         res = get_user(bad_token)
     except Exception as e:
         assert isinstance(e, SmartcarException)
+
+
+def test_wrong_vehicle_id(vw_egolf):
+    try:
+        vw_egolf.odometer()
+    except Exception as e:
+        assert isinstance(e, SmartcarException)
+
+        # 8 fields stated in exception.py + 'message'
+        assert len(e.__dict__.keys()) == 9
+        assert e.status_code == 403

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -1,51 +1,77 @@
 import requests.structures as rs
+import smartcar.types as ty
 
 
 # Tests
 def test_vin_and_meta(chevy_volt):
     vin = chevy_volt.vin()
     assert vin is not None
+    assert type(vin) == ty.Vin
+    assert vin._fields == ("vin", "meta")
     assert type(vin.meta) == rs.CaseInsensitiveDict
 
 
 def test_charge(chevy_volt):
     charge = chevy_volt.charge()
     assert charge is not None
+    assert type(charge) == ty.Charge
+    assert charge._fields == ("is_plugged_in", "status", "meta")
+    assert charge.is_plugged_in is not None
 
 
 def test_battery(chevy_volt):
     battery = chevy_volt.battery()
     assert battery is not None
+    assert type(battery) == ty.Battery
+    assert battery._fields == ("percent_remaining", "range", "meta")
 
 
 def test_battery_capacity(chevy_volt):
-    battery = chevy_volt.battery_capacity()
-    assert battery is not None
+    battery_capacity = chevy_volt.battery_capacity()
+    assert battery_capacity is not None
+    assert type(battery_capacity) == ty.BatteryCapacity
+    assert battery_capacity._fields == ("capacity", "meta")
 
 
 def test_fuel(chevy_volt):
     fuel = chevy_volt.fuel()
     assert fuel is not None
+    assert type(fuel) == ty.Fuel
+    assert fuel._fields == ("range", "percent_remaining", "amount_remaining", "meta")
 
 
 def test_tire_pressure(chevy_volt):
     tire_pressure = chevy_volt.tire_pressure()
     assert tire_pressure is not None
+    assert type(tire_pressure) == ty.TirePressure
+    assert tire_pressure._fields == (
+        "front_left",
+        "front_right",
+        "back_left",
+        "back_right",
+        "meta",
+    )
 
 
 def test_engine_oil(chevy_volt):
-    oil = chevy_volt.engine_oil()
-    assert oil is not None
+    engine_oil = chevy_volt.engine_oil()
+    assert engine_oil is not None
+    assert type(engine_oil) == ty.EngineOil
+    assert engine_oil._fields == ("life_remaining", "meta")
 
 
 def test_odometer(chevy_volt):
     odometer = chevy_volt.odometer()
     assert odometer is not None
+    assert type(odometer) == ty.Odometer
+    assert odometer._fields == ("distance", "meta")
 
 
 def test_location(chevy_volt):
     location = chevy_volt.location()
     assert location is not None
+    assert type(location) == ty.Location
+    assert location._fields == ("latitude", "longitude", "meta")
 
 
 def test_attributes(chevy_volt):
@@ -58,26 +84,35 @@ def test_attributes(chevy_volt):
 def test_lock(chevy_volt):
     lock = chevy_volt.lock()
     assert lock.status == "success"
+    assert type(lock) == ty.Status
+    assert lock._fields == ("status", "meta")
 
 
 def test_unlock(chevy_volt):
     unlock = chevy_volt.unlock()
     assert unlock.status == "success"
+    assert type(unlock) == ty.Status
+    assert unlock._fields == ("status", "meta")
 
 
 def test_start_charge(vw_egolf):
     response = vw_egolf.start_charge()
     assert response.status == "success"
+    assert type(response) == ty.Status
+    assert response._fields == ("status", "meta")
 
 
 def test_stop_charge(vw_egolf):
     response = vw_egolf.stop_charge()
     assert response.status == "success"
+    assert type(response) == ty.Status
+    assert response._fields == ("status", "meta")
 
 
 def test_batch(chevy_volt):
     batch = chevy_volt.batch(["/odometer", "/location"])
     assert batch is not None
+    assert batch._fields == ("odometer", "location", "meta")
 
     # assert meta and nested meta types
     assert type(batch.meta) == rs.CaseInsensitiveDict
@@ -87,6 +122,8 @@ def test_batch(chevy_volt):
 def test_permissions(chevy_volt):
     permissions = chevy_volt.permissions()
     assert permissions is not None
+    assert type(permissions) == ty.Permissions
+    assert permissions._fields == ("permissions", "meta")
 
 
 def test_batch_and_set_unit_system(chevy_volt):
@@ -98,3 +135,5 @@ def test_batch_and_set_unit_system(chevy_volt):
 def test_disconnect(chevy_volt):
     disconnected = chevy_volt.disconnect()
     assert disconnected is not None
+    assert type(disconnected) == ty.Status
+    assert disconnected._fields == ("status", "meta")

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -48,9 +48,11 @@ def test_location(chevy_volt):
     assert location is not None
 
 
-def test_info(chevy_volt):
-    info = chevy_volt.info()
-    assert info is not None
+def test_attributes(chevy_volt):
+    attributes = chevy_volt.attributes()
+    assert attributes is not None
+    assert type(attributes) == ty.Attributes
+    assert attributes._fields == ("id", "make", "model", "year", "meta")
 
 
 def test_lock(chevy_volt):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -15,7 +15,7 @@ def test_charge(chevy_volt):
     charge = chevy_volt.charge()
     assert charge is not None
     assert type(charge) == ty.Charge
-    assert charge._fields == ("is_plugged_in", "status", "meta")
+    assert charge._fields == ("is_plugged_in", "state", "meta")
     assert charge.is_plugged_in is not None
 
 
@@ -82,31 +82,31 @@ def test_attributes(chevy_volt):
 
 
 def test_lock(chevy_volt):
-    lock = chevy_volt.lock()
-    assert lock.status == "success"
-    assert type(lock) == ty.Status
-    assert lock._fields == ("status", "meta")
+    response = chevy_volt.lock()
+    assert response.status == "success"
+    assert type(response) == ty.Action
+    assert response._fields == ("status", "message", "meta")
 
 
 def test_unlock(chevy_volt):
-    unlock = chevy_volt.unlock()
-    assert unlock.status == "success"
-    assert type(unlock) == ty.Status
-    assert unlock._fields == ("status", "meta")
+    response = chevy_volt.unlock()
+    assert response.status == "success"
+    assert type(response) == ty.Action
+    assert response._fields == ("status", "message", "meta")
 
 
 def test_start_charge(vw_egolf):
     response = vw_egolf.start_charge()
     assert response.status == "success"
-    assert type(response) == ty.Status
-    assert response._fields == ("status", "meta")
+    assert type(response) == ty.Action
+    assert response._fields == ("status", "message", "meta")
 
 
 def test_stop_charge(vw_egolf):
     response = vw_egolf.stop_charge()
     assert response.status == "success"
-    assert type(response) == ty.Status
-    assert response._fields == ("status", "meta")
+    assert type(response) == ty.Action
+    assert response._fields == ("status", "message", "meta")
 
 
 def test_batch(chevy_volt):

--- a/tests/integration/test_auth_client.py
+++ b/tests/integration/test_auth_client.py
@@ -1,4 +1,6 @@
 import smartcar.auth_client as ac
+import urllib.parse as urlparse
+import tests.auth_helpers as ah
 
 
 def test_correct_keys_in_access_object(access_object):
@@ -23,6 +25,30 @@ def test_auth_client(client):
     assert client.client_secret is not None
     assert client.redirect_uri is not None
     assert client.test_mode
+
+
+def test_get_auth_url_with_options(client):
+    options = {
+        "force_prompt": True,
+        "state": "WEEEEEEEEE",
+        "make_bypass": "Ford",
+        "single_select": {"enabled": True, "vin": "abcdefghi12345678"},
+        "flags": {"flag_1": "Yay", "flag_2": True, "flag_3": 123},
+    }
+
+    test_url = client.get_auth_url(["read_odometer", "read_vehicle_info"], options)
+    query_params = urlparse.parse_qs(test_url)
+
+    assert query_params["client_id"][0] == ah.CLIENT_ID
+    assert query_params["redirect_uri"][0] == ah.REDIRECT_URI
+    assert query_params["approval_prompt"][0] == "force"
+    assert query_params["scope"][0] == "read_odometer read_vehicle_info"
+    assert query_params["mode"][0] == "test"
+    assert query_params["state"][0] == "WEEEEEEEEE"
+    assert query_params["make"][0] == "Ford"
+    assert query_params["single_select"][0] == "True"
+    assert query_params["single_select_vin"][0] == "abcdefghi12345678"
+    assert query_params["flags"][0] == "flag_1:Yay flag_2:True flag_3:123"
 
 
 def test_set_expiration(access_object):


### PR DESCRIPTION
- refactor: Changed `info()` to `attributes` and updated all tests
- refactor: Updated returns on start/stop charge and lock/unlock methods to return `Action` object, which has an attribute of 'message'
- refactor: Updated `Charge` to have attribute of `state` instead of `status`
- docs: Updated REFERENCE docs to reflect changes to action method
- fix: Fixed typo with `SmartcarException` for `docURL` attribute
- chore: Reviewed and updated method docstrings and type hints
- test: Changed testing suite to run fixtures for entire session, rather than per module 
- test: Added type and attribute tests on `smartcar.Vehicle` tests
- test: Updated testing suite to test `AuthClient.get_auth_url()` with full `options` argument