### PR TITLE
fix: CONTRIBUTING documentation env variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ and client secret. You'll also need to add the testing redirect URI to your appl
 
 ```
 export E2E_SMARTCAR_CLIENT_ID='<Your client id>'
-export E2E_SMARTCAR_CLIENT_ID='<Your client secret>'
+export E2E_SMARTCAR_CLIENT_SECRET='<Your client secret>'
 export E2E_SMARTCAR_REDIRECT_URI='<Your redirect URI>'
 ```
 


### PR DESCRIPTION
Typo in `CONTRIBUTING` documentation. Set the correct environment variable.