### PR TITLE
Change Test Fixture From Ford to Tesla

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def chevy_volt_limited_scope(client):
 
 # # Tesla
 @pytest.fixture(scope="session")
-def access_tesla(client):
+def access_ford(client):
     """
     Using the client fixture, go through Smartcar connect auth
     flow and acquire an access object. This object will have
@@ -138,13 +138,13 @@ def access_tesla(client):
         access_tesla namedtuple
     """
     client = sc.AuthClient(*ah.get_auth_client_params())
-    code = ah.run_auth_flow(client.get_auth_url(["required:control_charge"]), "TESLA")
+    code = ah.run_auth_flow(client.get_auth_url(["required:control_charge"]), "FORD")
     access = client.exchange_code(code)
     yield access
 
 
 @pytest.fixture(scope="session")
-def tesla_model_s(access_tesla):
+def ford_car(access_ford):
     """
     Using a separate instance of smartcar.AuthClient,
     run the Smartcar connect auth flow with different scope of permissions and
@@ -152,6 +152,6 @@ def tesla_model_s(access_tesla):
     Yields:
         tesla(smartcar.Vehicle)
     """
-    vehicle_ids = sc.get_vehicles(access_tesla.access_token)
+    vehicle_ids = sc.get_vehicles(access_ford.access_token)
     tesla_id = vehicle_ids.vehicles[0]
-    yield sc.Vehicle(tesla_id, access_tesla.access_token)
+    yield sc.Vehicle(tesla_id, access_ford.access_token)

--- a/tests/e2e/test_exception.py
+++ b/tests/e2e/test_exception.py
@@ -62,12 +62,12 @@ def test_vehicle_state_error_v1(access):
         assert "resolution" not in e.__dict__
 
 
-def test_out_of_permission_scope(tesla_model_s):
+def test_out_of_permission_scope(ford_car):
     """
     status code: 403, no "error" code
     """
     try:
-        tesla_model_s.odometer()
+        ford_car.odometer()
     except Exception as e:
         assert isinstance(e, SmartcarException)
 
@@ -81,14 +81,14 @@ def test_out_of_permission_scope(tesla_model_s):
         assert "type" in e.resolution.keys() and "url" in e.resolution.keys()
 
 
-def test_out_of_permission_scope_v1(access_tesla, tesla_model_s):
+def test_out_of_permission_scope_v1(access_ford, ford_car):
     """
     v1 permission error, code is None
     """
     try:
         smartcar.set_api_version("1.0")
         tesla_for_v1_api = smartcar.Vehicle(
-            tesla_model_s.vehicle_id, access_tesla.access_token
+            ford_car.vehicle_id, access_ford.access_token
         )
         tesla_for_v1_api.odometer()
     except Exception as e:

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -96,15 +96,15 @@ def test_unlock(chevy_volt):
     assert response._fields == ("status", "message", "meta")
 
 
-def test_start_charge(tesla_model_s):
-    response = tesla_model_s.start_charge()
+def test_start_charge(ford_car):
+    response = ford_car.start_charge()
     assert response.status == "success"
     assert type(response) == types.Action
     assert response._fields == ("status", "message", "meta")
 
 
-def test_stop_charge(tesla_model_s):
-    response = tesla_model_s.stop_charge()
+def test_stop_charge(ford_car):
+    response = ford_car.stop_charge()
     assert response.status == "success"
     assert type(response) == types.Action
     assert response._fields == ("status", "message", "meta")


### PR DESCRIPTION
Changing test fixture from ford to tesla to avoid captcha pop-up in oemAuth.