### PR TITLE
feat(vehicle): add request method to Vehicle

### DIFF
--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -204,7 +204,7 @@ Subscribe = NamedTuple(
     [("webhook_id", str), ("vehicle_id", str), ("meta", namedtuple)],
 )
 
-Response = NamedTuple("Response", [("body", dict), ("meta", dict)])
+Response = NamedTuple("Response", [("body", dict), ("meta", namedtuple)])
 
 # ===========================================
 # Named Tuple Selector Function

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -204,6 +204,8 @@ Subscribe = NamedTuple(
     [("webhook_id", str), ("vehicle_id", str), ("meta", namedtuple)],
 )
 
+Response = NamedTuple("Response", [("body", dict), ("meta", dict)])
+
 # ===========================================
 # Named Tuple Selector Function
 # ===========================================
@@ -330,6 +332,9 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
             headers,
         )
 
+    elif path == "request":
+        return Response(data, headers)
+        
     elif type(data) == dict:
         return generate_named_tuple(data, "Data")
 

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -334,7 +334,7 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
 
     elif path == "request":
         return Response(data, headers)
-        
+
     elif type(data) == dict:
         return generate_named_tuple(data, "Data")
 

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -457,10 +457,10 @@ class Vehicle(object):
             method (str): The HTTP request method to use.
             path (str): The path to make the request to.
             body (dict): The request body.
-            headers (dict): The headers to inlcude in the request.
+            headers (dict): The headers to include in the request.
 
         Returns:
-            Response = NamedTuple("Response", [("body", dict), ("meta", dict)])
+            Response = NamedTuple("Response", [("body", dict), ("meta", namedtuple)])
 
         Raises:
             SmartcarException
@@ -474,7 +474,7 @@ class Vehicle(object):
                 need_unit_system=(not has_units_header)
             )
             headers.update(generated_headers)
-
+    
         response = helpers.requester(method, url, headers=headers, json=body)
 
         return types.select_named_tuple("request", response)

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -474,7 +474,7 @@ class Vehicle(object):
                 need_unit_system=(not has_units_header)
             )
             headers.update(generated_headers)
-    
+
         response = helpers.requester(method, url, headers=headers, json=body)
 
         return types.select_named_tuple("request", response)

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -443,12 +443,13 @@ class Vehicle(object):
         return types.select_named_tuple("unsubscribe", response)
 
     # ===========================================
-    # Request Method (General Purpose)
+    # General Purpose Request Method
     # ===========================================
 
     def request(self, method: str, path: str, body: dict = {}, headers: dict = {}) -> types.Response:
         """
-        Make a request to a Smartcar endpoint
+        Utility method to make a request to a Smartcar endpoint - can be used 
+        to make requests to brand specific endpoints.
 
         Args:
             method (str): The HTTP request method to use.

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -446,9 +446,11 @@ class Vehicle(object):
     # General Purpose Request Method
     # ===========================================
 
-    def request(self, method: str, path: str, body: dict = {}, headers: dict = {}) -> types.Response:
+    def request(
+        self, method: str, path: str, body: dict = {}, headers: dict = {}
+    ) -> types.Response:
         """
-        Utility method to make a request to a Smartcar endpoint - can be used 
+        Utility method to make a request to a Smartcar endpoint - can be used
         to make requests to brand specific endpoints.
 
         Args:
@@ -467,14 +469,16 @@ class Vehicle(object):
 
         # Authorization header not provided
         if not "Authorization" in headers:
-            has_units_header = ("sc-unit-system" in headers)
-            generated_headers = self._get_headers(need_unit_system=(not has_units_header))
+            has_units_header = "sc-unit-system" in headers
+            generated_headers = self._get_headers(
+                need_unit_system=(not has_units_header)
+            )
             headers.update(generated_headers)
 
         response = helpers.requester(method, url, headers=headers, json=body)
 
         return types.select_named_tuple("request", response)
-        
+
     # ===========================================
     # Utility
     # ===========================================

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -443,7 +443,7 @@ class Vehicle(object):
         return types.select_named_tuple("unsubscribe", response)
 
     # ===========================================
-    # Request Method
+    # Request Method (General Purpose)
     # ===========================================
 
     def request(self, method: str, path: str, body: dict = {}, headers: dict = {}) -> types.Response:

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -443,6 +443,38 @@ class Vehicle(object):
         return types.select_named_tuple("unsubscribe", response)
 
     # ===========================================
+    # Request Method
+    # ===========================================
+
+    def request(self, method: str, path: str, body: dict = {}, headers: dict = {}) -> types.Response:
+        """
+        Make a request to a Smartcar endpoint
+
+        Args:
+            method (str): The HTTP request method to use.
+            path (str): The path to make the request to.
+            body (dict): The request body.
+            headers (dict): The headers to inlcude in the request.
+
+        Returns:
+            Response = NamedTuple("Response", [("body", dict), ("meta", dict)])
+
+        Raises:
+            SmartcarException
+        """
+        url = self._format_url(path)
+
+        # Authorization header not provided
+        if not "Authorization" in headers:
+            has_units_header = ("sc-unit-system" in headers)
+            generated_headers = self._get_headers(need_unit_system=(not has_units_header))
+            headers.update(generated_headers)
+
+        response = helpers.requester(method, url, headers=headers, json=body)
+
+        return types.select_named_tuple("request", response)
+        
+    # ===========================================
     # Utility
     # ===========================================
     def set_unit_system(self, unit_system: str) -> None:

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -202,6 +202,23 @@ def test_webhooks(chevy_volt):
         assert unsubscribe._fields == ("status", "meta")
 
 
+def test_request(chevy_volt):
+    odometer = chevy_volt.request("GET", "odometer", None, {"sc-unit-system": "imperial"})
+    assert odometer.body is not None
+    assert isinstance(odometer.meta, tuple)
+    assert odometer._fields == ("body", "meta")
+    assert odometer.meta.unit_system == "imperial"
+
+def test_request_override_header(chevy_volt):
+    try:
+        chevy_volt.request("GET", "odometer", None, {
+        "sc-unit-system": "imperial",
+        "Authorization": 'Bearer abc',
+        })
+    except SmartcarException as sc_e:
+        assert sc_e.message == "AUTHENTICATION - The authorization header is missing or malformed, or it contains invalid or expired authentication credentials. Please check for missing parameters, spelling and casing mistakes, and other syntax issues."
+
+
 def test_chevy_imperial(chevy_volt_imperial):
     response = chevy_volt_imperial.odometer()
     assert response.meta.unit_system == "imperial"

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -237,14 +237,19 @@ def test_request_with_body(chevy_volt):
         "batch",
         {"requests": [{"path": "/odometer"}, {"path": "/tires/pressure"}]},
     )
-    assert type(batch) == types.Response
+    print(batch)
+    assert type(batch) is types.Response
     assert batch.body is not None
     assert isinstance(batch.meta, tuple)
     assert batch.body["responses"][0]["path"] == "/odometer"
     assert batch.body["responses"][0]["path"] == "/odometer"
     assert batch.body["responses"][0]["code"] == 200
-    assert type(batch.body["responses"][0]["body"]["distance"]) == float
+    assert isinstance(batch.body["responses"][0]["body"]["distance"], float)
     assert batch.body["responses"][1]["path"] == "/tires/pressure"
+    assert isinstance(batch.body["responses"][1]["body"]["frontLeft"], float)
+    assert isinstance(batch.body["responses"][1]["body"]["frontRight"], float)
+    assert isinstance(batch.body["responses"][1]["body"]["backLeft"], float)
+    assert isinstance(batch.body["responses"][1]["body"]["backRight"], float)
     
 
 def test_chevy_imperial(chevy_volt_imperial):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -204,6 +204,7 @@ def test_webhooks(chevy_volt):
 
 def test_request(chevy_volt):
     odometer = chevy_volt.request("GET", "odometer", None, {"sc-unit-system": "imperial"})
+    assert type(odometer) == types.Response
     assert odometer.body is not None
     assert isinstance(odometer.meta, tuple)
     assert odometer._fields == ("body", "meta")
@@ -217,6 +218,14 @@ def test_request_override_header(chevy_volt):
         })
     except SmartcarException as sc_e:
         assert sc_e.message == "AUTHENTICATION - The authorization header is missing or malformed, or it contains invalid or expired authentication credentials. Please check for missing parameters, spelling and casing mistakes, and other syntax issues."
+
+
+def test_request_with_body(chevy_volt):
+    response = chevy_volt.request("POST", "security", {"action": "LOCK"})
+    assert response.body["status"] == "success"
+    assert type(response) == types.Response
+    assert response.body["status"] is not None
+    assert response.body["message"] is not None
 
 
 def test_chevy_imperial(chevy_volt_imperial):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -237,7 +237,6 @@ def test_request_with_body(chevy_volt):
         "batch",
         {"requests": [{"path": "/odometer"}, {"path": "/tires/pressure"}]},
     )
-    print(batch)
     assert type(batch) is types.Response
     assert batch.body is not None
     assert isinstance(batch.meta, tuple)

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -250,7 +250,7 @@ def test_request_with_body(chevy_volt):
     assert isinstance(batch.body["responses"][1]["body"]["frontRight"], float)
     assert isinstance(batch.body["responses"][1]["body"]["backLeft"], float)
     assert isinstance(batch.body["responses"][1]["body"]["backRight"], float)
-    
+
 
 def test_chevy_imperial(chevy_volt_imperial):
     response = chevy_volt_imperial.odometer()

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -203,21 +203,32 @@ def test_webhooks(chevy_volt):
 
 
 def test_request(chevy_volt):
-    odometer = chevy_volt.request("GET", "odometer", None, {"sc-unit-system": "imperial"})
+    odometer = chevy_volt.request(
+        "GET", "odometer", None, {"sc-unit-system": "imperial"}
+    )
     assert type(odometer) == types.Response
     assert odometer.body is not None
     assert isinstance(odometer.meta, tuple)
     assert odometer._fields == ("body", "meta")
     assert odometer.meta.unit_system == "imperial"
 
+
 def test_request_override_header(chevy_volt):
     try:
-        chevy_volt.request("GET", "odometer", None, {
-        "sc-unit-system": "imperial",
-        "Authorization": 'Bearer abc',
-        })
+        chevy_volt.request(
+            "GET",
+            "odometer",
+            None,
+            {
+                "sc-unit-system": "imperial",
+                "Authorization": "Bearer abc",
+            },
+        )
     except SmartcarException as sc_e:
-        assert sc_e.message == "AUTHENTICATION - The authorization header is missing or malformed, or it contains invalid or expired authentication credentials. Please check for missing parameters, spelling and casing mistakes, and other syntax issues."
+        assert (
+            sc_e.message
+            == "AUTHENTICATION - The authorization header is missing or malformed, or it contains invalid or expired authentication credentials. Please check for missing parameters, spelling and casing mistakes, and other syntax issues."
+        )
 
 
 def test_request_with_body(chevy_volt):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -232,12 +232,20 @@ def test_request_override_header(chevy_volt):
 
 
 def test_request_with_body(chevy_volt):
-    response = chevy_volt.request("POST", "security", {"action": "LOCK"})
-    assert response.body["status"] == "success"
-    assert type(response) == types.Response
-    assert response.body["status"] is not None
-    assert response.body["message"] is not None
-
+    batch = chevy_volt.request(
+        "post",
+        "batch",
+        {"requests": [{"path": "/odometer"}, {"path": "/tires/pressure"}]},
+    )
+    assert type(batch) == types.Response
+    assert batch.body is not None
+    assert isinstance(batch.meta, tuple)
+    assert batch.body["responses"][0]["path"] == "/odometer"
+    assert batch.body["responses"][0]["path"] == "/odometer"
+    assert batch.body["responses"][0]["code"] == 200
+    assert type(batch.body["responses"][0]["body"]["distance"]) == float
+    assert batch.body["responses"][1]["path"] == "/tires/pressure"
+    
 
 def test_chevy_imperial(chevy_volt_imperial):
     response = chevy_volt_imperial.odometer()


### PR DESCRIPTION
Add a new general purpose and BSE related method `request(self, method: str, path: str, body: dict = {}, headers: dict = {}) -> types.Response` to Vehicle that allows for making requests to the Smartcar API. Also adds new type Response to types.py.

Test Plan: create a simple app with my Smartcar Developer account and make requests with this method once it's in prod.

Asana: https://app.asana.com/0/1201332815308984/1201617268953139/f