### PR TITLE
feat(smartcar): adds API v2.0 compatibility functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - '3.7'
   - '3.8'
   - '3.9'
+  - '3.10'
 
 if: tag IS blank # do not build tags
 
@@ -35,7 +36,7 @@ script:
 jobs:
   include:
     - stage: publish
-      python: '3.8'
+      python: '3.9'
       services: []
       addons:
         firefox: 'skip'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ jobs:
         firefox: 'skip'
         apt: []
       install:
-        - nvm install 14
-        - npm install semantic-release@15.x.x @google/semantic-release-replace-plugin@1.x.x
+        - nvm install 16
+        - npm install semantic-release@19.x.x @google/semantic-release-replace-plugin@1.x.x
       script:
         - npx semantic-release
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 
 services:
   - xvfb

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -694,6 +694,8 @@ A compatible vehicle is a vehicle that:
 2. belongs to the makes and models Smartcar supports, and
 3. supports the permissions.
 
+**\*Note:** the options (dict) argument is only valid for Smartcar API v1.0.
+
 #### Arguments
 
 | Parameter               | Type       | Required     | Description                                                                                                                                                  |
@@ -709,11 +711,17 @@ A compatible vehicle is a vehicle that:
 
 #### Return
 
-| Value                      | Type                   | Description                                                                           |
-|:---------------------------|:-----------------------|:--------------------------------------------------------------------------------------|
-| `Compatibility`            | typing.NamedTuple      | The returned object with vehicle's compatibility with the permissions (scope) checked |
-| `Compatibility.compatible` | Boolean                | Whether the vehicle is compatible with the permissions                                |
-| `Compatibility.meta`       | collections.namedtuple | Smartcar response headers (`request_id`, `data_age`, and/or `unit_system`)            |
+| Value                                     | Type                    | Availability          | Description                                                                                                                                         |
+|:------------------------------------------|:------------------------|:----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Compatibility`                           | typing.NamedTuple       | **API v1.0 and v2.0** |The returned object with vehicle's compatibility with the permissions (scope) checked                                                                | 
+| `Compatibility.compatible`                | Boolean                 | **API v1.0 and v2.0** | Whether the vehicle is compatible with the permissions                                                                                              |
+| `Compatibility.reason`                    | String or None          | **API v2.0 only**     | One of the following string values if compatible is false, null otherwise: "VEHICLE_NOT_COMPATIBLE", "MAKE_NOT_COMPATIBLE"                          |
+| `Compatibility.capabilities`              | List                    | **API v2.0 only**     | A list containing the set of endpoints that the provided scope value can provide authorization for. This list will be empty if compatible is false. |
+| `Compatibility.capabilities[].permission` | String                  | **API v2.0 only**     | One of the permissions provided in the scope parameter.                                                                                             |
+| `Compatibility.capabilities[].endpoint`   | String                  | **API v2.0 only**     | One of the endpoints that the permission authorizes access to.                                                                                      |
+| `Compatibility.capabilities[].capable`    | Boolean                 | **API v2.0 only**     | True if the vehicle is likely capable of this feature, False otherwise.                                                                             |
+| `Compatibility.capabilities[].reason`     | String or None          | **API v2.0 only**     | One of the following string values if compatible is false, null otherwise: "VEHICLE_NOT_COMPATIBLE", "SMARTCAR_NOT_CAPABLE"                         |
+| `Compatibility.meta`                      | collections.namedtuple  | **API v1.0 and v2.0** | Smartcar response headers (`request_id`, `data_age`, and/or `unit_system`)                                                                          |
 
 #### Raises
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -694,8 +694,6 @@ A compatible vehicle is a vehicle that:
 2. belongs to the makes and models Smartcar supports, and
 3. supports the permissions.
 
-**\*Note:** the options (dict) argument is only valid for Smartcar API v1.0.
-
 #### Arguments
 
 | Parameter               | Type       | Required     | Description                                                                                                                                                  |

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -102,7 +102,7 @@ def get_compatibility(
         3. Is compatible with the required permissions (scope) that your app is requesting
             access to
 
-    Note: the options (dict) argument is only valid for Smartcar API v1.0.
+    Note: The `test_mode` and `test_mode_compatibility_level` options arguments are only valid for Smartcar API v1.0.
 
     Args:
         vin (str)
@@ -151,15 +151,15 @@ def get_compatibility(
         client_id = options.get("client_id", client_id)
         client_secret = options.get("client_secret", client_secret)
         api_version = options.get("version", api_version)
-        
+
+        if options.get("flags"):
+            flags_str = helpers.format_flag_query(options["flags"])
+            params["flags"] = flags_str
+
+        if options.get("version"):
+            api_version = options["version"]
+
         if api_version == "1.0":
-
-            if options.get("flags"):
-                flags_str = helpers.format_flag_query(options["flags"])
-                params["flags"] = flags_str
-
-            if options.get("version"):
-                api_version = options["version"]
 
             if options.get("test_mode_compatibility_level"):
                 params["mode"] = "test"
@@ -174,7 +174,7 @@ def get_compatibility(
         raise Exception(
             "'get_compatibility' requires a client_id AND client_secret. "
             "Either set these as environment variables, OR pass them in as part of the 'options'"
-            "dictionary, if using v2.0). The recommended course of action is to set up environment variables"
+            "dictionary). The recommended course of action is to set up environment variables"
             "with your client credentials. i.e.: "
             "'SMARTCAR_CLIENT_ID' and 'SMARTCAR_CLIENT_SECRET'"
         )

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -174,7 +174,7 @@ def get_compatibility(
         raise Exception(
             "'get_compatibility' requires a client_id AND client_secret. "
             "Either set these as environment variables, OR pass them in as part of the 'options'"
-            "dictionary). The recommended course of action is to set up environment variables"
+            "dictionary. The recommended course of action is to set up environment variables"
             "with your client credentials. i.e.: "
             "'SMARTCAR_CLIENT_ID' and 'SMARTCAR_CLIENT_SECRET'"
         )

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -62,6 +62,31 @@ def test_get_compatibility_in_test_mode_but_no_level():
         )
 
 
+def test_get_compatibility_v2():
+    set_api_version("2.0")
+
+    compatibility = smartcar.get_compatibility(
+        "0SCGMCT0386A85356",
+        scope=["read_odometer", "read_fuel"],
+        country="US",
+        options={
+            "client_id": ah.CLIENT_ID,
+            "client_secret": ah.CLIENT_SECRET,
+        },
+    )
+
+    assert compatibility.compatible == True
+    assert compatibility.reason == None
+    assert compatibility.capabilities[0].permission == "read_odometer"
+    assert compatibility.capabilities[0].endpoint == "/odometer"
+    assert compatibility.capabilities[0].capable == True
+    assert compatibility.capabilities[0].reason == None
+    assert compatibility.capabilities[1].permission == "read_fuel"
+    assert compatibility.capabilities[1].endpoint == "/fuel"
+    assert compatibility.capabilities[1].capable == False
+    assert compatibility.capabilities[1].reason == "VEHICLE_NOT_CAPABLE"
+
+
 def test_get_compatibility_with_non_test_mode_vin():
     res = get_compatibility(
         "WAUAFAFL1GN014882",

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -63,7 +63,6 @@ def test_get_compatibility_in_test_mode_but_no_level():
 
 
 def test_get_compatibility_v2():
-    set_api_version("2.0")
 
     compatibility = smartcar.get_compatibility(
         "0SCGMCT0386A85356",
@@ -72,6 +71,7 @@ def test_get_compatibility_v2():
         options={
             "client_id": ah.CLIENT_ID,
             "client_secret": ah.CLIENT_SECRET,
+            "version": "2.0",
         },
     )
 


### PR DESCRIPTION
 Adds API v2.0 compatibility functionality to `smartcar.get_compatibility` method and updates docs (reference.md) for compatibility.

Adds types (namedtuple's) `CompatibilityV1` and `CompatibilityV2` to return from `smartcar.get_compatibility` method.

Test Plan: Use updated method in getting-started app.

Asana: https://app.asana.com/0/1122465745219696/1201987199141658/f