### PR TITLE
fix: Adds `is_expired` function to main scope.

### DIFF
--- a/smartcar/__init__.py
+++ b/smartcar/__init__.py
@@ -12,6 +12,7 @@ from smartcar.smartcar import (
     get_api_version,
     set_api_version,
     verify_payload,
+    is_expired,
 )
 
 from smartcar.vehicle import Vehicle


### PR DESCRIPTION
To comply with the SDK Reference, the `is_expired` function is added to the main `smartcar` scope.

This fixes #110