### PR TITLE
fix: update string for semantic-release lib to replace with actual version

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -10,7 +10,7 @@ module.exports = {
         replacements: [
           {
             files: ['smartcar/__init__.py'],
-            from: "__version__ = \"semantic-release\"",
+            from: "__version__ = \"0.0.0\"",
             to: "__version__ = \"${nextRelease.version}\"",
             results: [
               {


### PR DESCRIPTION
The semantic-release library used in CI will try to automatically update a specified string with the detected version. This PR changes that string from 'semantic-release' to '0.0.0' in the releaserc.js