### PR TITLE
Fix: Add Checks for `/batch` calls

### DIFF
--- a/smartcar/helpers.py
+++ b/smartcar/helpers.py
@@ -114,12 +114,15 @@ def format_path_and_attribute_for_batch(raw_path: str) -> tuple:
         2. "NORMAL" raw_path == '/odometer' -> ('odometer', 'odometer')
         3. "NESTED" raw_path == '/engine/oil' -> ('engine/oil', 'engine_oil')
     """
+    # mapper holds unique situations where the path does not exactly line up with the function to call
+    # we have a set_charge_limit but are not concerned with it in batch calls
     mapper = {
-        "battery/capacity": "battery_capacity",
-        "engine/oil": "engine_oil",
-        "tires/pressure": "tire_pressure",
+        "charge/limit": "get_charge_limit",
         "": "attributes",
     }
     formatted_path = raw_path[1:] if raw_path[0] == "/" else raw_path
     formatted_attribute = mapper.get(formatted_path, formatted_path)
+    if "/" in formatted_attribute:
+        formatted_attribute = formatted_attribute.replace('/', '_')
+
     return formatted_path, formatted_attribute

--- a/smartcar/helpers.py
+++ b/smartcar/helpers.py
@@ -123,6 +123,6 @@ def format_path_and_attribute_for_batch(raw_path: str) -> tuple:
     formatted_path = raw_path[1:] if raw_path[0] == "/" else raw_path
     formatted_attribute = mapper.get(formatted_path, formatted_path)
     if "/" in formatted_attribute:
-        formatted_attribute = formatted_attribute.replace('/', '_')
+        formatted_attribute = formatted_attribute.replace("/", "_")
 
     return formatted_path, formatted_attribute

--- a/smartcar/helpers.py
+++ b/smartcar/helpers.py
@@ -118,6 +118,7 @@ def format_path_and_attribute_for_batch(raw_path: str) -> tuple:
     # we have a set_charge_limit but are not concerned with it in batch calls
     mapper = {
         "charge/limit": "get_charge_limit",
+        "tires/pressure": "tire_pressure",
         "": "attributes",
     }
     formatted_path = raw_path[1:] if raw_path[0] == "/" else raw_path

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -125,9 +125,9 @@ def test_set_charge_limit(ford_car):
 
 
 def test_batch_success(chevy_volt):
-    batch = chevy_volt.batch(["/odometer", "/location"])
+    batch = chevy_volt.batch(["/odometer", "/location", "/charge/limit"])
     assert batch is not None
-    assert batch._fields == ("odometer", "location", "meta")
+    assert batch._fields == ("odometer", "location", "get_charge_limit", "meta")
     assert isinstance(batch.meta, tuple)
     assert isinstance(batch.odometer().meta, tuple)
     assert batch.odometer().distance is not None
@@ -135,6 +135,7 @@ def test_batch_success(chevy_volt):
     assert batch.location().longitude is not None
     assert batch.location().latitude is not None
     assert batch.location().meta.request_id is not None
+    assert batch.get_charge_limit().limit is not None
 
 
 def test_batch_misspelled_permission(chevy_volt):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -125,9 +125,26 @@ def test_set_charge_limit(ford_car):
 
 
 def test_batch_success(chevy_volt):
-    batch = chevy_volt.batch(["/odometer", "/location", "/charge/limit", "/engine/oil", "/battery/capacity", "/tires/pressure"])
+    batch = chevy_volt.batch(
+        [
+            "/odometer",
+            "/location",
+            "/charge/limit",
+            "/engine/oil",
+            "/battery/capacity",
+            "/tires/pressure",
+        ]
+    )
     assert batch is not None
-    assert batch._fields == ("odometer", "location", "get_charge_limit", "engine_oil", "battery_capacity", "tire_pressure", "meta")
+    assert batch._fields == (
+        "odometer",
+        "location",
+        "get_charge_limit",
+        "engine_oil",
+        "battery_capacity",
+        "tire_pressure",
+        "meta",
+    )
     assert isinstance(batch.meta, tuple)
     assert isinstance(batch.odometer().meta, tuple)
     assert batch.odometer().distance is not None
@@ -142,7 +159,6 @@ def test_batch_success(chevy_volt):
     assert batch.tire_pressure().front_left is not None
     assert batch.tire_pressure().back_right is not None
     assert batch.tire_pressure().back_left is not None
-
 
 
 def test_batch_misspelled_permission(chevy_volt):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -125,9 +125,9 @@ def test_set_charge_limit(ford_car):
 
 
 def test_batch_success(chevy_volt):
-    batch = chevy_volt.batch(["/odometer", "/location", "/charge/limit"])
+    batch = chevy_volt.batch(["/odometer", "/location", "/charge/limit", "/engine/oil", "/battery/capacity", "/tires/pressure"])
     assert batch is not None
-    assert batch._fields == ("odometer", "location", "get_charge_limit", "meta")
+    assert batch._fields == ("odometer", "location", "get_charge_limit", "engine_oil", "battery_capacity", "tire_pressure", "meta")
     assert isinstance(batch.meta, tuple)
     assert isinstance(batch.odometer().meta, tuple)
     assert batch.odometer().distance is not None
@@ -136,6 +136,13 @@ def test_batch_success(chevy_volt):
     assert batch.location().latitude is not None
     assert batch.location().meta.request_id is not None
     assert batch.get_charge_limit().limit is not None
+    assert batch.engine_oil().life_remaining is not None
+    assert batch.battery_capacity().capacity is not None
+    assert batch.tire_pressure().front_right is not None
+    assert batch.tire_pressure().front_left is not None
+    assert batch.tire_pressure().back_right is not None
+    assert batch.tire_pressure().back_left is not None
+
 
 
 def test_batch_misspelled_permission(chevy_volt):


### PR DESCRIPTION
This PR adds checks to nested paths to replace forward slashes with underscores.

In unique situations, we need to map to a different value. In that case, we can add them to our mapper dictionary.

Asana: https://app.asana.com/0/1122465745219696/1204244572926037/f
