### PR TITLE
chore: remove is_expired from docs and smartcar.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,7 @@ This access object will look like this:
 ```
 
 - To make any vehicle data request to the Smartcar API, you'll need to give the SDK a valid **access token**. Access
-  tokens will expire every 2 hours, so you'll need to constantly refresh them. To check if an access object is expired,
-  use `smartcar.is_expired(access['expiration'])`.
-
-```python
-smartcar.is_expired(access['expiration']) # True or False
-```
+  tokens will expire every 2 hours, so you'll need to constantly refresh them.
 
 - It was pretty hard getting that first access token, but from now on it's easy!
   Calling `client.exchange_refresh_token(refresh_token)` will return a new access object using a previous access
@@ -98,12 +93,10 @@ smartcar.is_expired(access['expiration']) # True or False
 ```python
 def get_fresh_access():
     access = load_access_from_database()
-    if smartcar.is_expired(access['expiration']):
-        new_access = client.exchange_refresh_token(access['refresh_token'])
-        put_access_into_database(new_access)
-        return new_access
-    else:
-        return access
+    new_access = client.exchange_refresh_token(access['refresh_token'])
+    put_access_into_database(new_access)
+    
+    return new_access
 
 
 fresh_access_token = get_fresh_access()['access_token']

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -609,25 +609,6 @@ Sets the version of Smartcar API to use
 | None |
 
 ---
-
-### `smartcar.is_expired(expiration)`
-
-Check if an expiration is expired
-
-#### Arguments
-
-| Parameter    | Type     | Description         |
-|:-------------|:---------|:--------------------|
-| `expiration` | DateTime | expiration datetime |
-
-#### Returns
-
-| Type    | Description     |
-|:--------|:----------------|
-| Boolean | true if expired |
-
----
-
 ### `smartcar.get_vehicles(access_token, limit=10, offset=0)`
 
 Get a list of the user's vehicle ids

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -215,22 +215,6 @@ def get_compatibility(
         raise Exception("Please use a valid API version (e.g. '1.0' or '2.0')")
 
 
-def is_expired(expiration: datetime) -> bool:
-    """
-    Check if an expiration is expired.
-    This helper method can be used on the 'expiration' or 'refresh_expiration'
-    values from the 'access object' received after going through Smartcar
-    Connect Auth flow.
-
-    Args:
-        expiration (datetime): expiration datetime
-
-    Returns:
-        bool: true if expired
-    """
-    return datetime.utcnow() > expiration
-
-
 # ===========================================
 # Webhook functions
 # ===========================================


### PR DESCRIPTION
This PR will remove the `is_expired` smartcar method, since we've removed it from init.py exports. It also removes is_expired from the SDK documentation.

Asana: https://app.asana.com/0/1204781601661821/1204818165183873/f