### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     [
-      '@google/semantic-release-replace-plugin',
+      'semantic-release-replace-plugin',
       {
         replacements: [
           {

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
         apt: []
       install:
         - nvm install 16
-        - npm install semantic-release@19.x.x @google/semantic-release-replace-plugin@1.x.x
+        - npm install semantic-release@19.x.x semantic-release-replace-plugin@1.x.x
       script:
         - npx semantic-release
       deploy:


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).