### PR TITLE
feat(tests): add support for Chrome WebDriver and configurable browser option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,12 @@ Please be sure to read the contribution guidelines before making or requesting a
 
 #### Requirements:
 
-You will need [geckodriver](https://github.com/mozilla/geckodriver/releases) (and subsequently, Firefox) to run tests
+To run tests, you will need the appropriate WebDriver for your chosen browser. This guide assumes you are using either Firefox or Chrome:
+
+- For Firefox, download [geckodriver](https://github.com/mozilla/geckodriver/releases).
+- For Chrome, download [chromedriver](https://chromedriver.chromium.org/downloads).
+
+Ensure that the chosen driver is in your system's PATH, or you can specify the path directly in your test scripts.
 
 The tests make requests to the Smartcar API, so you'll need to create an application on Smartcar and get your client id
 and client secret. You'll also need to add the testing redirect URI to your application.
@@ -54,6 +59,16 @@ pytest tests/e2e/test_vehicle.py::test_vehicle
 pytest -s tests/e2e/test_vehicle.py::test_odometer
 
 # Refer to pytest docs for more about pytest!
+```
+
+#### Configuring the Browser for Testing:
+
+You can specify which browser to use for running the tests by setting the `BROWSER` environment variable. If not set, it defaults to Firefox:
+
+```bash
+export BROWSER='firefox'  # Use Firefox
+# or
+export BROWSER='chrome'   # Use Chrome
 ```
 
 ## Formatting

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -443,9 +443,9 @@ class Vehicle(object):
                     "sc-request-id"
                 )
                 # use lambda default args to avoid issues with closures
-                batch_dict[attribute] = (
-                    lambda p=path, r=res_dict: types.select_named_tuple(p, r)
-                )
+                batch_dict[
+                    attribute
+                ] = lambda p=path, r=res_dict: types.select_named_tuple(p, r)
             else:
                 # if individual response is erroneous, attach a lambda that returns a SmartcarException
                 def _attribute_raise_exception(smartcar_exception):
@@ -455,9 +455,9 @@ class Vehicle(object):
                 headers = response.headers
                 body = json.dumps(res_dict.get("body"))
                 sc_exception = sce.exception_factory(code, headers, body)
-                batch_dict[attribute] = (
-                    lambda e=sc_exception: _attribute_raise_exception(e)
-                )
+                batch_dict[
+                    attribute
+                ] = lambda e=sc_exception: _attribute_raise_exception(e)
 
         # STEP 3 - Attach Meta to batch_dict
         batch_dict["meta"] = types.build_meta(response.headers)

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -443,9 +443,9 @@ class Vehicle(object):
                     "sc-request-id"
                 )
                 # use lambda default args to avoid issues with closures
-                batch_dict[
-                    attribute
-                ] = lambda p=path, r=res_dict: types.select_named_tuple(p, r)
+                batch_dict[attribute] = (
+                    lambda p=path, r=res_dict: types.select_named_tuple(p, r)
+                )
             else:
                 # if individual response is erroneous, attach a lambda that returns a SmartcarException
                 def _attribute_raise_exception(smartcar_exception):
@@ -455,9 +455,9 @@ class Vehicle(object):
                 headers = response.headers
                 body = json.dumps(res_dict.get("body"))
                 sc_exception = sce.exception_factory(code, headers, body)
-                batch_dict[
-                    attribute
-                ] = lambda e=sc_exception: _attribute_raise_exception(e)
+                batch_dict[attribute] = (
+                    lambda e=sc_exception: _attribute_raise_exception(e)
+                )
 
         # STEP 3 - Attach Meta to batch_dict
         batch_dict["meta"] = types.build_meta(response.headers)

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -6,8 +6,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from distutils.util import strtobool
-from selenium.webdriver.chrome.service import Service as ChromeService   
-from selenium.webdriver.chrome.options import Options as ChromeOptions   
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.chrome.options import Options as ChromeOptions
 
 import smartcar.helpers as helpers
 
@@ -60,6 +60,7 @@ def get_code_from_url(url):
 
     return search_params["code"]
 
+
 def get_driver(browser_name, headless=False):
     if browser_name.lower() == "chrome":
         chrome_options = ChromeOptions()
@@ -71,7 +72,7 @@ def get_driver(browser_name, headless=False):
         driver = webdriver.Firefox(options=firefox_options)
     else:
         raise ValueError("Unsupported browser: {}".format(browser_name))
-    
+
     return driver
 
 

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -6,6 +6,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from distutils.util import strtobool
+from selenium.webdriver.chrome.service import Service as ChromeService   
+from selenium.webdriver.chrome.options import Options as ChromeOptions   
 
 import smartcar.helpers as helpers
 
@@ -15,6 +17,7 @@ helpers.validate_env(mode="test")
 # Smartcar client environment variables (Required)
 CLIENT_ID = os.environ["E2E_SMARTCAR_CLIENT_ID"]
 CLIENT_SECRET = os.environ["E2E_SMARTCAR_CLIENT_SECRET"]
+BROWSER = os.environ.get("BROWSER", "firefox")
 REDIRECT_URI = "https://example.com/auth"
 
 # Variables for testing webhooks (Optional):
@@ -57,11 +60,23 @@ def get_code_from_url(url):
 
     return search_params["code"]
 
+def get_driver(browser_name, headless=False):
+    if browser_name.lower() == "chrome":
+        chrome_options = ChromeOptions()
+        chrome_options.headless = headless
+        driver = webdriver.Chrome(options=chrome_options)
+    elif browser_name.lower() == "firefox":
+        firefox_options = webdriver.FirefoxOptions()
+        firefox_options.headless = headless
+        driver = webdriver.Firefox(options=firefox_options)
+    else:
+        raise ValueError("Unsupported browser: {}".format(browser_name))
+    
+    return driver
+
 
 def run_auth_flow(auth_url, brand="CHEVROLET"):
-    firefox_options = webdriver.FirefoxOptions()
-    firefox_options.headless = HEADLESS
-    driver = webdriver.Firefox(options=firefox_options)
+    driver = get_driver(BROWSER, headless=True)
 
     driver.get(auth_url)
     # Preamble


### PR DESCRIPTION
## Overview

This pull request implements the capability to run tests using either Firefox or Chrome WebDriver, enhancing the flexibility and adaptability of our testing environment. This update follows the addition of an environment variable `BROWSER`, which lets the user specify the browser for running tests. The default setting remains Firefox, ensuring backward compatibility.

## Changes

- **CONTRIBUTING.md**: Updated the document to include instructions on downloading ChromeDriver and configuring the `BROWSER` environment variable.
- **auth_helpers.py**: Extended to support the initialization of both Firefox and Chrome WebDrivers based on the `BROWSER` environment variable. A new function `get_driver` has been created to encapsulate the browser initialization logic, replacing direct calls to Firefox WebDriver with a more flexible function that supports both browsers.


