### PR TITLE
feat: get_compatability_matrix

### DIFF
--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -62,10 +62,7 @@ class AuthClient(object):
 
         self.auth = (self.client_id, self.client_secret)
 
-        if (
-            self.client_id is None
-            or self.client_secret is None
-        ):
+        if self.client_id is None or self.client_secret is None:
             raise Exception(
                 "AuthClient MUST have client_id and client_secret attributes."
                 "Either set these as environment variables, OR pass them in as arguments when instantiating "

--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -21,13 +21,14 @@ class AuthClient(object):
         """
         A client for accessing the Smartcar API.
 
-        NOTE: It is recommended that you set environment variables with your client id, secret, and redirect URI.
+        NOTE: It is recommended that you set environment variables with your client id and secret.
         AuthClient by default will search for environment variables "SMARTCAR_CLIENT_ID",
         "SMARTCAR_CLIENT_SECRET", and "SMARTCAR_REDIRECT_URL" and set those as attributes.
         These CAN be passed as arguments as you instantiate AuthClient. Any arguments passed in will override
         and take precedence over the corresponding environment variable.
 
-        However, if neither an environment variable nor an argument is passed in, an exception will be raised.
+        Client ID and Client Secret are required, either via arguments or environment variables.
+        However, redirect_uri is now optional due to Vehicle Access in the dashboard.
 
         Args:
             client_id (str, optional): The application id, provided in the application
@@ -38,7 +39,8 @@ class AuthClient(object):
 
             redirect_uri (str, optional): The URL to redirect to after the user accepts
                 or declines the application's permissions. This URL must also be
-                present in the Redirect URIs field in the application dashboard
+                present in the Redirect URIs field in the application dashboard.
+                Now optional with Vehicle Access in the dashboard.
 
             test_mode (bool, optional): Deprecated, please use `mode` instead.
                 Launch Smartcar Connect in [test mode](https://smartcar.com/docs/guides/testing/).
@@ -63,26 +65,26 @@ class AuthClient(object):
         if (
             self.client_id is None
             or self.client_secret is None
-            or self.redirect_uri is None
         ):
             raise Exception(
-                "AuthClient MUST have client_id, client_secret, and redirect_uri attributes."
+                "AuthClient MUST have client_id and client_secret attributes."
                 "Either set these as environment variables, OR pass them in as arguments when instantiating "
                 "AuthClient. The recommended course of action is to set up environment variables "
                 "with your client credentials. i.e.: "
-                "'SMARTCAR_CLIENT_ID', 'SMARTCAR_CLIENT_SECRET', and 'SMARTCAR_REDIRECT_URI'"
+                "'SMARTCAR_CLIENT_ID' and 'SMARTCAR_CLIENT_SECRET'"
             )
         if self.mode not in ["test", "live", "simulated"]:
             raise Exception(
                 "The \"mode\" parameter MUST be one of the following: 'test', 'live', 'simulated'",
             )
 
-    def get_auth_url(self, scope: List[str], options: dict = None) -> str:
+    def get_auth_url(self, scope: List[str] = None, options: dict = None) -> str:
         """
         Generate the Connect URL
 
         Args:
-            scope (str[], required): A list of permissions requested by the application
+            scope (str[], optional): A list of permissions requested by the application.
+                Now optional with Vehicle Access in the dashboard.
 
             options (dict, optional): Can have the following keys:
 
@@ -124,11 +126,16 @@ class AuthClient(object):
         query = {
             "response_type": "code",
             "client_id": self.client_id,
-            "redirect_uri": self.redirect_uri,
             "approval_prompt": "auto",
-            "scope": " ".join(scope),
             "mode": self.mode,
         }
+
+        # Add optional parameters if they exist
+        if self.redirect_uri:
+            query["redirect_uri"] = self.redirect_uri
+
+        if scope:
+            query["scope"] = " ".join(scope)
 
         if options:
             if options.get("force_prompt"):
@@ -184,8 +191,11 @@ class AuthClient(object):
         data = {
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": self.redirect_uri,
         }
+
+        # Add redirect_uri if it exists
+        if self.redirect_uri:
+            data["redirect_uri"] = self.redirect_uri
         params = {}
 
         if options:

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -62,7 +62,9 @@ def get_user(access_token: str) -> types.User:
     return types.select_named_tuple("user", response)
 
 
-def get_compatibility_by_region_and_make(region: str, make: str, options: dict = None) -> types.CompatibilityMatrix:
+def get_compatibility_matrix(
+    region: str, make: str, options: dict = None
+) -> types.CompatibilityMatrix:
     """
     Retrieve compatibility matrix for a given region and make.
     This API is for reference purposes only and does not guarantee compatibility for a specific vehicle.
@@ -85,7 +87,9 @@ def get_compatibility_by_region_and_make(region: str, make: str, options: dict =
     if not client_secret:
         client_secret = os.environ.get("SMARTCAR_CLIENT_SECRET")
     if client_id is None or client_secret is None:
-        raise Exception("SMARTCAR_CLIENT_ID and SMARTCAR_CLIENT_SECRET must be set in environment variables or passed in options.")
+        raise Exception(
+            "SMARTCAR_CLIENT_ID and SMARTCAR_CLIENT_SECRET must be set in environment variables or passed in options."
+        )
 
     # Build query params
     params = {"region": region}
@@ -117,7 +121,8 @@ def get_compatibility_by_region_and_make(region: str, make: str, options: dict =
                 type=m["type"],
                 endpoints=m["endpoints"],
                 permissions=m["permissions"],
-            ) for m in models
+            )
+            for m in models
         ]
     return matrix
 
@@ -272,7 +277,6 @@ def get_compatibility(
         return types.select_named_tuple("compatibility_v2", response)
     else:
         raise Exception("Please use a valid API version (e.g. '1.0' or '2.0')")
-
 
 
 # ===========================================

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -62,6 +62,66 @@ def get_user(access_token: str) -> types.User:
     return types.select_named_tuple("user", response)
 
 
+def get_compatibility_by_region_and_make(region: str, make: str, options: dict = None) -> types.CompatibilityMatrix:
+    """
+    Retrieve compatibility matrix for a given region and make.
+    This API is for reference purposes only and does not guarantee compatibility for a specific vehicle.
+
+    Args:
+        region (str): One of US, CA, EUROPE
+        make (str): Vehicle make (e.g. 'tesla', 'nissan'). If empty, all makes returned.
+        options (dict, optional): Can include 'type' (ICE, BEV, PHEV, HEV), 'scope' (list of permissions)
+
+    Returns:
+        CompatibilityMatrix: Dict[str, List[CompatibilityMatrixModel]]
+    """
+    client_id = None
+    client_secret = None
+    if options:
+        client_id = options.get("client_id")
+        client_secret = options.get("client_secret")
+    if not client_id:
+        client_id = os.environ.get("SMARTCAR_CLIENT_ID")
+    if not client_secret:
+        client_secret = os.environ.get("SMARTCAR_CLIENT_SECRET")
+    if client_id is None or client_secret is None:
+        raise Exception("SMARTCAR_CLIENT_ID and SMARTCAR_CLIENT_SECRET must be set in environment variables or passed in options.")
+
+    # Build query params
+    params = {"region": region}
+    if make:
+        params["make"] = make
+    if options:
+        if "type" in options:
+            params["type"] = options["type"]
+        if "scope" in options and options["scope"]:
+            params["scope"] = " ".join(options["scope"])
+
+    # Auth header
+    id_secret = f"{client_id}:{client_secret}"
+    base64_id_secret = base64.b64encode(id_secret.encode("ascii")).decode("ascii")
+    headers = {"Authorization": f"Basic {base64_id_secret}"}
+
+    url = f"{config.API_URL}/v{API_VERSION}/compatibility/matrix"
+    response = helpers.requester("GET", url, headers=headers, params=params)
+
+    # Parse response into types.CompatibilityMatrix
+    data = response.json() or {}
+    matrix = {}
+    for make_key, models in data.items():
+        matrix[make_key] = [
+            types.CompatibilityMatrixModel(
+                model=m["model"],
+                startYear=m["startYear"],
+                endYear=m["endYear"],
+                type=m["type"],
+                endpoints=m["endpoints"],
+                permissions=m["permissions"],
+            ) for m in models
+        ]
+    return matrix
+
+
 def get_vehicles(access_token: str, paging: dict = None) -> types.Vehicles:
     """
     Get a list of the user's vehicle ids
@@ -212,6 +272,7 @@ def get_compatibility(
         return types.select_named_tuple("compatibility_v2", response)
     else:
         raise Exception("Please use a valid API version (e.g. '1.0' or '2.0')")
+
 
 
 # ===========================================

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -545,11 +545,13 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
     else:
         return data
 
+
 # ===========================================
 # compatibility matrix response
 # ===========================================
 
 from typing import Dict
+
 
 class CompatibilityMatrixModel(NamedTuple):
     model: str
@@ -558,6 +560,7 @@ class CompatibilityMatrixModel(NamedTuple):
     type: str
     endpoints: List[str]
     permissions: List[str]
+
 
 # Dict[str, List[CompatibilityMatrixModel]]
 CompatibilityMatrix = Dict[str, List[CompatibilityMatrixModel]]

--- a/smartcar/types.py
+++ b/smartcar/types.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import namedtuple
-from typing import List, Optional, NamedTuple, Union
+from typing import List, Optional, NamedTuple, Union, Dict, Any
 import re
 import requests.structures as rs
 import enum
@@ -544,3 +544,20 @@ def select_named_tuple(path: str, response_or_dict) -> NamedTuple:
 
     else:
         return data
+
+# ===========================================
+# compatibility matrix response
+# ===========================================
+
+from typing import Dict
+
+class CompatibilityMatrixModel(NamedTuple):
+    model: str
+    startYear: int
+    endYear: int
+    type: str
+    endpoints: List[str]
+    permissions: List[str]
+
+# Dict[str, List[CompatibilityMatrixModel]]
+CompatibilityMatrix = Dict[str, List[CompatibilityMatrixModel]]

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -13,6 +13,7 @@ from selenium.webdriver.chrome.options import Options as ChromeOptions
 
 import smartcar.helpers as helpers
 
+
 # Pure Python strtobool implementation (compatible with Python 3.9+)
 def strtobool(val):
     val = str(val).lower()
@@ -22,6 +23,7 @@ def strtobool(val):
         return False
     else:
         raise ValueError(f"invalid truth value {val}")
+
 
 # Configure logging
 logging.basicConfig(

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -7,10 +7,21 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 
 import smartcar.helpers as helpers
+
+# Pure Python strtobool implementation (compatible with Python 3.9+)
+def strtobool(val):
+    val = str(val).lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val}")
 
 # Configure logging
 logging.basicConfig(

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -41,19 +41,19 @@ def test_get_vehicles_with_paging(access):
     # ...existing code...
 
 
-
-def test_e2e_get_compatibility_by_region_and_make():
+def test_e2e_get_compatibility_matrix():
     # This test will call the real API. Requires valid SMARTCAR_CLIENT_ID and SMARTCAR_CLIENT_SECRET in env.
     region = "US"
     make = "TESLA"
     options = {
-        "type": "BEV", "scope": ["read_battery", "read_charge"],
+        "type": "BEV",
+        "scope": ["read_battery", "read_charge"],
         "client_id": ah.CLIENT_ID,
         "client_secret": ah.CLIENT_SECRET,
         "mode": "test",
     }
 
-    matrix = smartcar.smartcar.get_compatibility_by_region_and_make(region, make, options)
+    matrix = smartcar.smartcar.get_compatibility_matrix(region, make, options)
     assert isinstance(matrix, dict)
     assert make.upper() in matrix
     assert isinstance(matrix[make.upper()], list)

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -38,7 +38,9 @@ def test_get_vehicles(access):
 
 def test_get_vehicles_with_paging(access):
     paging = {"limit": 1, "offset": 1}
-    # ...existing code...
+    res = get_vehicles(access.access_token, paging)
+    assert res.paging.offset == 1
+    assert len(res.vehicles) == 0
 
 
 def test_e2e_get_compatibility_matrix():

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -38,9 +38,35 @@ def test_get_vehicles(access):
 
 def test_get_vehicles_with_paging(access):
     paging = {"limit": 1, "offset": 1}
-    res = get_vehicles(access.access_token, paging)
-    assert res.paging.offset == 1
-    assert len(res.vehicles) == 0
+    # ...existing code...
+
+
+
+def test_e2e_get_compatibility_by_region_and_make():
+    # This test will call the real API. Requires valid SMARTCAR_CLIENT_ID and SMARTCAR_CLIENT_SECRET in env.
+    region = "US"
+    make = "TESLA"
+    options = {
+        "type": "BEV", "scope": ["read_battery", "read_charge"],
+        "client_id": ah.CLIENT_ID,
+        "client_secret": ah.CLIENT_SECRET,
+        "mode": "test",
+    }
+
+    matrix = smartcar.smartcar.get_compatibility_by_region_and_make(region, make, options)
+    assert isinstance(matrix, dict)
+    assert make.upper() in matrix
+    assert isinstance(matrix[make.upper()], list)
+    # Check at least one model exists for the make
+    assert len(matrix[make.upper()]) > 0
+    # Check required fields in the first model
+    first_model = matrix[make.upper()][0]
+    assert hasattr(first_model, "model")
+    assert hasattr(first_model, "startYear")
+    assert hasattr(first_model, "endYear")
+    assert hasattr(first_model, "type")
+    assert hasattr(first_model, "endpoints")
+    assert hasattr(first_model, "permissions")
 
 
 def test_get_compatibility_v2():

--- a/tests/unit/test_auth_client_optional_params.py
+++ b/tests/unit/test_auth_client_optional_params.py
@@ -1,0 +1,84 @@
+import os
+import urllib.parse as urlparse
+import tests.auth_helpers as ah
+from smartcar import AuthClient
+
+
+def test_auth_client_without_redirect_uri():
+    """Test that AuthClient can be created without a redirect_uri."""
+    # Save original environment variables
+    original_redirect_uri = os.environ.get("SMARTCAR_REDIRECT_URI")
+
+    try:
+        # Remove redirect_uri from environment
+        if "SMARTCAR_REDIRECT_URI" in os.environ:
+            del os.environ["SMARTCAR_REDIRECT_URI"]
+
+        # Create client without redirect_uri
+        client = AuthClient(
+            client_id=ah.CLIENT_ID,
+            client_secret=ah.CLIENT_SECRET,
+            mode="test"
+        )
+
+        # Should not raise exception
+        assert client.redirect_uri is None
+    finally:
+        # Restore environment variables
+        if original_redirect_uri:
+            os.environ["SMARTCAR_REDIRECT_URI"] = original_redirect_uri
+
+
+def test_get_auth_url_without_scope():
+    """Test that get_auth_url works without a scope parameter."""
+    client = AuthClient(*ah.get_auth_client_params())
+
+    # Call get_auth_url without scope
+    test_url = client.get_auth_url()
+    query_params = urlparse.parse_qs(test_url)
+
+    # Should include required parameters
+    assert query_params["client_id"][0] == ah.CLIENT_ID
+    assert query_params["redirect_uri"][0] == ah.REDIRECT_URI
+    assert query_params["approval_prompt"][0] == "auto"
+    assert "scope" not in query_params
+
+    # With options but no scope
+    options = {"state": "test_state"}
+    test_url = client.get_auth_url(options=options)
+    query_params = urlparse.parse_qs(test_url)
+
+    assert query_params["state"][0] == "test_state"
+    assert "scope" not in query_params
+
+
+def test_auth_url_with_all_optional_params():
+    """Test creating an auth URL with all optional parameters."""
+    # Create client without redirect_uri
+    original_redirect_uri = os.environ.get("SMARTCAR_REDIRECT_URI")
+
+    try:
+        # Remove redirect_uri from environment
+        if "SMARTCAR_REDIRECT_URI" in os.environ:
+            del os.environ["SMARTCAR_REDIRECT_URI"]
+
+        # Create client without redirect_uri
+        client = AuthClient(
+            client_id=ah.CLIENT_ID,
+            client_secret=ah.CLIENT_SECRET,
+            mode="test"
+        )
+
+        # Call get_auth_url without scope or redirect_uri
+        test_url = client.get_auth_url()
+        query_params = urlparse.parse_qs(test_url)
+
+        # Should include required parameters
+        assert query_params["client_id"][0] == ah.CLIENT_ID
+        assert "redirect_uri" not in query_params
+        assert "scope" not in query_params
+
+    finally:
+        # Restore environment variables
+        if original_redirect_uri:
+            os.environ["SMARTCAR_REDIRECT_URI"] = original_redirect_uri

--- a/tests/unit/test_auth_client_optional_params.py
+++ b/tests/unit/test_auth_client_optional_params.py
@@ -16,9 +16,7 @@ def test_auth_client_without_redirect_uri():
 
         # Create client without redirect_uri
         client = AuthClient(
-            client_id=ah.CLIENT_ID,
-            client_secret=ah.CLIENT_SECRET,
-            mode="test"
+            client_id=ah.CLIENT_ID, client_secret=ah.CLIENT_SECRET, mode="test"
         )
 
         # Should not raise exception
@@ -64,9 +62,7 @@ def test_auth_url_with_all_optional_params():
 
         # Create client without redirect_uri
         client = AuthClient(
-            client_id=ah.CLIENT_ID,
-            client_secret=ah.CLIENT_SECRET,
-            mode="test"
+            client_id=ah.CLIENT_ID, client_secret=ah.CLIENT_SECRET, mode="test"
         )
 
         # Call get_auth_url without scope or redirect_uri


### PR DESCRIPTION
This PR adds a `get_compatability_matrix` method, which calls the [Smartcar Compatibility API -  By Region and Make ](https://smartcar.com/docs/api-reference/compatibility/by-region-and-make) endpoint.

This PR also tweaks `scope` and `redirect_uri` params to be optional args.