### PR TITLE
Add self.retry_after variable to SmartcarException class 

### DIFF
--- a/smartcar/exception.py
+++ b/smartcar/exception.py
@@ -24,6 +24,8 @@ class SmartcarException(Exception):
                     self.__dict__[key] = formatted_resolution
                 else:
                     self.__dict__[key] = {"type": None, "url": None}
+            elif key == "retry_after":
+                self.retry_after = kwargs[key]
             else:
                 self.__dict__[key] = kwargs[key] or None
 


### PR DESCRIPTION
fix(Exception.py): Add self.retry_after variable to SmartcarException class.

This commit adds the self.retry_after variable to SmartcarException and assigns the "Retry after" header to it. This enables users to access the SmartcarException.retry_after variable so that they can fully and intuitively automate the API call process if a rate limit occurs.