### PR TITLE
feat: API V3 Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ signals_response = vehicle.get_signals()
 print(signals_response.body)
 
 # Calling GET signals/{signal_code} endpoint
-odometer_response = signals.get("odometer-travelleddistance")
+odometer_response = vehicle.get_signal("odometer-travelleddistance")
 print(odometer_response.body)
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ def get_fresh_access():
     access = load_access_from_database()
     new_access = client.exchange_refresh_token(access['refresh_token'])
     put_access_into_database(new_access)
-    
     return new_access
 
 
@@ -125,16 +124,13 @@ vehicle_id = vehicle.vehicles[0]
 ```python
 vehicle = smartcar.Vehicle(vehicle_id, access_token)
 
-odometer = vehicle.odometer()
-print(odometer.distance)
+# Calling GET signals endpoint
+signals_response = vehicle.get_signals()
+print(signals_response.body)
 
-info = vehicle.info()
-print(info.make)
-print(info.model)
-
-batch = vehicle.batch(paths=['/location'])
-location = batch.location()
-print(location)
+# Calling GET signals/{signal_code} endpoint
+odometer_response = signals.get("odometer-travelleddistance")
+print(odometer_response.body)
 ```
 
 - For a lot more examples on everything you can do with a car, see

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ print(vehicles.vehicles)
 
 # Vehicle ID of first vehicle
 vehicle_id = vehicle.vehicles[0]
+
+# Get attributes of the first vehicle
+vehicle_response = smartcar.get_vehicle(access_token, vehicle_id)
+print(vehicle_response.get("body"))
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ signals_response = vehicle.get_signals()
 print(signals_response.body)
 
 # Calling GET signals/{signal_code} endpoint
-odometer_response = vehicle.get_signal("odometer-travelleddistance")
+odometer_response = vehicle.get_signal("odometer-traveleddistance")
 print(odometer_response.body)
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -796,6 +796,32 @@ Sets the version of Smartcar API to use
 
 ---
 
+### `get_vehicle(access_token, vehicle_id)`
+
+Retrieves information for a specific vehicle using Smartcar API v3.
+
+#### Arguments
+
+| Parameter      | Type   | Required     | Description                                               |
+| :------------  | :----- | :----------- | :-------------------------------------------------------- |
+| `access_token` | String | **Required** | A valid access token for the vehicle.                     |
+| `vehicle_id`   | String | **Required** | The unique identifier of the vehicle to retrieve.         |
+
+#### Returns
+
+| Type       | Description                                                                 |
+| :--------- | :-------------------------------------------------------------------------- |
+| Dictionary | A dictionary with keys `body` and `headers`. `body` contains the vehicle data, and `headers` contains the response headers. |
+
+The returned dictionary provides access to all vehicle data in the `body` and the HTTP response headers in `headers`.
+
+#### Example
+
+```python
+vehicle_response = smartcar.get_vehicle(access_token, vehicle_id)
+print(vehicle_response.get("body"))
+```
+
 ### `smartcar.get_vehicles(access_token, limit=10, offset=0)`
 
 Get a list of the user's vehicle ids

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -152,6 +152,53 @@ Initializes a new Vehicle to use for making requests to the Smartcar API.
 | `options.version`     | String     | **Optional** | the version of Smartcar API that the instance of the vehicle will send requests to (e.g. '1.0' or '2.0') |
 
 ---
+### `get_signals(self)`
+
+Retrieves all available signals for the vehicle using Smartcar API v3.
+
+#### Arguments
+
+None
+
+#### Returns
+
+| Type       | Description                                                                 |
+| :--------- | :-------------------------------------------------------------------------- |
+| Dictionary | A dictionary with keys `body` and `headers`. `body` contains the signals data, and `headers` contains the response headers. |
+
+The returned dictionary provides access to all signals in the `body` and the HTTP response headers in `headers`.
+
+#### Example
+
+```python
+signals_response = vehicle.get_signals()
+print(signals_response.get("body"))
+```
+
+### `get_signal(self, signal_code)`
+
+Retrieves a specific signal for the vehicle using Smartcar API v3.
+
+#### Arguments
+
+| Parameter     | Type   | Required     | Description                                 |
+| :------------ | :----- | :----------- | :------------------------------------------ |
+| signal_code   | String | **Required** | The code of the signal to retrieve.         |
+
+#### Returns
+
+| Type       | Description                                                                 |
+| :--------- | :-------------------------------------------------------------------------- |
+| Dictionary | A dictionary with keys `body` and `headers`. `body` contains the signals data, and `headers` contains the response headers. |
+
+The returned dictionary provides access to all signals in the `body` and the HTTP response headers in `headers`.
+
+#### Example
+
+```python
+odometer_response = vehicle.get_signal("odometer-traveleddistance")
+print(odometer_response.get("body"))
+```
 
 ### `set_unit_system(self, unit_system)`
 

--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -118,7 +118,7 @@ class AuthClient(object):
         Raises:
             SmartcarException
         """
-        base_url = config.CONNECT_URL
+        base_url = config.CONNECT_ORIGIN
 
         query = {
             "response_type": "code",
@@ -184,7 +184,7 @@ class AuthClient(object):
             SmartcarException
         """
         method = "POST"
-        url = config.AUTH_URL
+        url = config.AUTH_ORIGIN
         data = {
             "grant_type": "authorization_code",
             "code": code,
@@ -228,7 +228,7 @@ class AuthClient(object):
             SmartcarException
         """
         method = "POST"
-        url = config.AUTH_URL
+        url = config.AUTH_ORIGIN
         data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
         params = {}
 

--- a/smartcar/auth_client.py
+++ b/smartcar/auth_client.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 import smartcar.config as config
 import smartcar.helpers as helpers
-import smartcar.types as types
+import smartcar.response.v2 as v2
 
 
 class AuthClient(object):
@@ -164,7 +164,7 @@ class AuthClient(object):
 
         return base_url + "/oauth/authorize?" + urlencode(query)
 
-    def exchange_code(self, code: str, options: dict = None) -> types.Access:
+    def exchange_code(self, code: str, options: dict = None) -> v2.Access:
         """
         Exchange an authentication code for an access dictionary
 
@@ -204,11 +204,11 @@ class AuthClient(object):
             method, url, data=data, auth=self.auth, params=params
         )
         data = response.json()
-        return types.make_access_object(_set_expiration(data))
+        return v2.make_access_object(_set_expiration(data))
 
     def exchange_refresh_token(
         self, refresh_token: str, options: dict = None
-    ) -> types.Access:
+    ) -> v2.Access:
         """
         Exchange a refresh token for a new access dictionary
 
@@ -241,7 +241,7 @@ class AuthClient(object):
             method, url, data=data, auth=self.auth, params=params
         )
         data = response.json()
-        return types.make_access_object(_set_expiration(data))
+        return v2.make_access_object(_set_expiration(data))
 
 
 # Static helpers for AuthClient

--- a/smartcar/config.py
+++ b/smartcar/config.py
@@ -4,10 +4,12 @@ API_ORIGIN = os.environ.get("SMARTCAR_API_ORIGIN", "https://api.smartcar.com")
 AUTH_ORIGIN = os.environ.get(
     "SMARTCAR_AUTH_ORIGIN", "https://auth.smartcar.com/oauth/token"
 )
-CONNECT_ORIGIN = os.environ.get("SMARTCAR_CONNECT_ORIGIN", "https://connect.smartcar.com")
+CONNECT_ORIGIN = os.environ.get(
+    "SMARTCAR_CONNECT_ORIGIN", "https://connect.smartcar.com"
+)
 MANAGEMENT_API_ORIGIN = os.environ.get(
     "SMARTCAR_MANAGEMENT_API_ORIGIN", "https://management.smartcar.com"
 )
-
 VEHICLE_API_ORIGIN = os.environ.get(
-    "SMARTCAR_VEHICLE_API_V3_ORIGIN", "https://vehicle.api.smartcar.com")
+    "SMARTCAR_VEHICLE_API_V3_ORIGIN", "https://vehicle.api.smartcar.com"
+)

--- a/smartcar/config.py
+++ b/smartcar/config.py
@@ -1,10 +1,13 @@
 import os
 
-API_URL = os.environ.get("SMARTCAR_API_ORIGIN", "https://api.smartcar.com")
-AUTH_URL = os.environ.get(
+API_ORIGIN = os.environ.get("SMARTCAR_API_ORIGIN", "https://api.smartcar.com")
+AUTH_ORIGIN = os.environ.get(
     "SMARTCAR_AUTH_ORIGIN", "https://auth.smartcar.com/oauth/token"
 )
-CONNECT_URL = os.environ.get("SMARTCAR_CONNECT_ORIGIN", "https://connect.smartcar.com")
-MANAGEMENT_API_URL = os.environ.get(
+CONNECT_ORIGIN = os.environ.get("SMARTCAR_CONNECT_ORIGIN", "https://connect.smartcar.com")
+MANAGEMENT_API_ORIGIN = os.environ.get(
     "SMARTCAR_MANAGEMENT_API_ORIGIN", "https://management.smartcar.com"
 )
+
+VEHICLE_API_ORIGIN = os.environ.get(
+    "SMARTCAR_VEHICLE_API_V3_ORIGIN", "https://vehicle.api.smartcar.com")

--- a/smartcar/exception.py
+++ b/smartcar/exception.py
@@ -108,7 +108,7 @@ def exception_factory(
     else:
         return SmartcarException(
             status_code=status_code,
-            request_id=headers["SC-Request-Id"],
+            request_id=headers.get("SC-Request-Id"),
             type="SDK_ERROR",
             message=body,
         )

--- a/smartcar/response/v2.py
+++ b/smartcar/response/v2.py
@@ -80,8 +80,9 @@ def build_meta(response_headers: rs.CaseInsensitiveDict) -> namedtuple:
 
     meta_dict = {}
     for key, value in smartcar_headers.items():
-        if key in response_headers:
-            meta_dict[value] = response_headers[key]
+        header = response_headers.get(key)
+        if header:
+            meta_dict[value] = header
 
     return generate_named_tuple(meta_dict, "Meta", True)
 

--- a/smartcar/response/v3/__init__.py
+++ b/smartcar/response/v3/__init__.py
@@ -1,0 +1,5 @@
+from typing import TypedDict, Any, Dict
+
+class Response(TypedDict):
+    body: Any
+    headers: Dict[str, Any]

--- a/smartcar/response/v3/__init__.py
+++ b/smartcar/response/v3/__init__.py
@@ -1,5 +1,6 @@
 from typing import TypedDict, Any, Dict
 
+
 class Response(TypedDict):
     body: Any
     headers: Dict[str, Any]

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 import smartcar.config as config
 import smartcar.helpers as helpers
-import smartcar.types as types
+import smartcar.response.v2 as v2
 
 API_VERSION = "2.0"
 
@@ -42,7 +42,7 @@ def get_api_version() -> str:
     return API_VERSION
 
 
-def get_user(access_token: str) -> types.User:
+def get_user(access_token: str) -> v2.User:
     """
     Retrieve the userId associated with the access_token
 
@@ -59,12 +59,12 @@ def get_user(access_token: str) -> types.User:
     headers = {"Authorization": f"Bearer {access_token}"}
     response = helpers.requester("GET", url, headers=headers)
 
-    return types.select_named_tuple("user", response)
+    return v2.select_named_tuple("user", response)
 
 
 def get_compatibility_matrix(
     region: str, make: str, options: dict = None
-) -> types.CompatibilityMatrix:
+) -> v2.CompatibilityMatrix:
     """
     Retrieve compatibility matrix for a given region and make.
     This API is for reference purposes only and does not guarantee compatibility for a specific vehicle.
@@ -114,7 +114,7 @@ def get_compatibility_matrix(
     matrix = {}
     for make_key, models in data.items():
         matrix[make_key] = [
-            types.CompatibilityMatrixModel(
+            v2.CompatibilityMatrixModel(
                 model=m["model"],
                 startYear=m["startYear"],
                 endYear=m["endYear"],
@@ -127,7 +127,7 @@ def get_compatibility_matrix(
     return matrix
 
 
-def get_vehicles(access_token: str, paging: dict = None) -> types.Vehicles:
+def get_vehicles(access_token: str, paging: dict = None) -> v2.Vehicles:
     """
     Get a list of the user's vehicle ids
 
@@ -151,12 +151,12 @@ def get_vehicles(access_token: str, paging: dict = None) -> types.Vehicles:
     params = paging if paging is not None else None
     response = helpers.requester("GET", url, headers=headers, params=params)
 
-    return types.select_named_tuple("vehicles", response)
+    return v2.select_named_tuple("vehicles", response)
 
 
 def get_compatibility(
     vin: str, scope: List[str], country: str = "US", options: dict = None
-) -> Union[types.CompatibilityV1, types.CompatibilityV2]:
+) -> Union[v2.CompatibilityV1, v2.CompatibilityV2]:
     """
     Verify if a vehicle (vin) is eligible to use Smartcar. Use to confirm whether
     specific vehicle is compatible with the permissions provided.
@@ -272,9 +272,9 @@ def get_compatibility(
     response = helpers.requester("GET", url, headers=headers, params=params)
 
     if api_version == "1.0":
-        return types.select_named_tuple("compatibility_v1", response)
+        return v2.select_named_tuple("compatibility_v1", response)
     elif api_version == "2.0":
-        return types.select_named_tuple("compatibility_v2", response)
+        return v2.select_named_tuple("compatibility_v2", response)
     else:
         raise Exception("Please use a valid API version (e.g. '1.0' or '2.0')")
 
@@ -333,7 +333,7 @@ def get_connections(
     amt: str,
     filter: Optional[Dict[str, str]] = None,
     paging: Optional[Dict[str, Optional[int]]] = None,
-) -> types.GetConnections:
+) -> v2.GetConnections:
     """
     Returns a paged list of all the vehicles that are connected to the application
     associated with the management API token used, sorted in descending order by connection date.
@@ -370,21 +370,21 @@ def get_connections(
     response = helpers.requester("GET", url, headers=headers, params=params)
     data = response.json()
     connections = [
-        types.Connection(c.get("vehicleId"), c.get("userId"), c.get("connectedAt"))
+        v2.Connection(c.get("vehicleId"), c.get("userId"), c.get("connectedAt"))
         for c in data["connections"]
     ]
 
     response_paging = data.get("paging", {})
-    response_paging = types.PagingCursor(response_paging.get("cursor"))
+    response_paging = v2.PagingCursor(response_paging.get("cursor"))
 
-    return types.GetConnections(
+    return v2.GetConnections(
         connections,
         response_paging,
-        types.build_meta(response.headers),
+        v2.build_meta(response.headers),
     )
 
 
-def delete_connections(amt: str, filter: dict = {}) -> types.DeleteConnections:
+def delete_connections(amt: str, filter: dict = {}) -> v2.DeleteConnections:
     """
     Deletes all the connections by vehicle or user ID and returns a list
     of all connections that were deleted.
@@ -420,11 +420,11 @@ def delete_connections(amt: str, filter: dict = {}) -> types.DeleteConnections:
     response = helpers.requester("DELETE", url, headers=headers, params=params)
     data = response.json()
     connections = [
-        types.Connection(c.get("vehicleId"), c.get("userId"), c.get("connectedAt"))
+        v2.Connection(c.get("vehicleId"), c.get("userId"), c.get("connectedAt"))
         for c in data["connections"]
     ]
 
-    return types.DeleteConnections(
+    return v2.DeleteConnections(
         connections,
-        types.build_meta(response.headers),
+        v2.build_meta(response.headers),
     )

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -9,6 +9,7 @@ from warnings import warn
 import smartcar.config as config
 import smartcar.helpers as helpers
 import smartcar.response.v2 as v2
+import smartcar.response.v3 as v3
 
 API_VERSION = "2.0"
 
@@ -125,6 +126,28 @@ def get_compatibility_matrix(
             for m in models
         ]
     return matrix
+
+
+def get_vehicle(access_token: str, vehicle_id: str) -> v3.Response:
+    """
+    GET vehicle/{vehicle_id} endpoint to retrieve vehicle information.
+
+    Args:
+        access_token (str): A valid access token from a previously retrieved
+            access object
+
+        vehicle_id (str): The vehicle ID of the vehicle to retrieve information for.
+
+    Returns:
+        Response: smartcar.response.v3.Response
+    """
+    url = f"{config.VEHICLE_API_ORIGIN}/v3/vehicles/{vehicle_id}"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = helpers.requester("GET", url, headers=headers)
+    return {
+        "body": response.json(),
+        "headers": response.headers,
+    }
 
 
 def get_vehicles(access_token: str, paging: dict = None) -> v2.Vehicles:

--- a/smartcar/smartcar.py
+++ b/smartcar/smartcar.py
@@ -55,7 +55,7 @@ def get_user(access_token: str) -> types.User:
     Raises:
         SmartcarException
     """
-    url = f"{config.API_URL}/v{API_VERSION}/user"
+    url = f"{config.API_ORIGIN}/v{API_VERSION}/user"
     headers = {"Authorization": f"Bearer {access_token}"}
     response = helpers.requester("GET", url, headers=headers)
 
@@ -106,7 +106,7 @@ def get_compatibility_matrix(
     base64_id_secret = base64.b64encode(id_secret.encode("ascii")).decode("ascii")
     headers = {"Authorization": f"Basic {base64_id_secret}"}
 
-    url = f"{config.API_URL}/v{API_VERSION}/compatibility/matrix"
+    url = f"{config.API_ORIGIN}/v{API_VERSION}/compatibility/matrix"
     response = helpers.requester("GET", url, headers=headers, params=params)
 
     # Parse response into types.CompatibilityMatrix
@@ -146,7 +146,7 @@ def get_vehicles(access_token: str, paging: dict = None) -> types.Vehicles:
     Raises:
         SmartcarException
     """
-    url = f"{config.API_URL}/v{API_VERSION}/vehicles"
+    url = f"{config.API_ORIGIN}/v{API_VERSION}/vehicles"
     headers = {"Authorization": f"Bearer {access_token}"}
     params = paging if paging is not None else None
     response = helpers.requester("GET", url, headers=headers, params=params)
@@ -260,7 +260,7 @@ def get_compatibility(
             "'SMARTCAR_CLIENT_ID' and 'SMARTCAR_CLIENT_SECRET'"
         )
 
-    url = f"{config.API_URL}/v{api_version}/compatibility"
+    url = f"{config.API_ORIGIN}/v{api_version}/compatibility"
 
     # Configuring for compatibility endpoint
     id_secret = f"{client_id}:{client_secret}"
@@ -365,7 +365,7 @@ def get_connections(
     if "limit" in paging:
         params["limit"] = paging["limit"]
 
-    url = f"{config.MANAGEMENT_API_URL}/v{get_api_version()}/management/connections/"
+    url = f"{config.MANAGEMENT_API_ORIGIN}/v{get_api_version()}/management/connections/"
     headers = {"Authorization": f"Basic {get_management_token(amt)}"}
     response = helpers.requester("GET", url, headers=headers, params=params)
     data = response.json()
@@ -415,7 +415,7 @@ def delete_connections(amt: str, filter: dict = {}) -> types.DeleteConnections:
     elif vehicle_id:
         params["vehicle_id"] = vehicle_id
 
-    url = f"{config.MANAGEMENT_API_URL}/v{get_api_version()}/management/connections/"
+    url = f"{config.MANAGEMENT_API_ORIGIN}/v{get_api_version()}/management/connections/"
     headers = {"Authorization": f"Basic {get_management_token(amt)}"}
     response = helpers.requester("DELETE", url, headers=headers, params=params)
     data = response.json()

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -4,7 +4,8 @@ from typing import Callable, List, Optional
 import smartcar.config as config
 import smartcar.helpers as helpers
 import smartcar.smartcar
-import smartcar.types as types
+import smartcar.response.v2 as v2
+import smartcar.response.v3 as v3
 import smartcar.exception as sce
 
 
@@ -50,7 +51,49 @@ class Vehicle(object):
             if options.get("flags"):
                 self._flags = options["flags"]
 
-    def vin(self) -> types.Vin:
+    def get_signals(self) -> v3.Response:
+        """
+        GET Vehicle.signals
+
+        Returns:
+            Response: smartcar.response.v3.Response
+        """
+        origin = config.VEHICLE_API_ORIGIN
+        api_version = "3"
+        path = "signals"
+        url = self._format_url(path, origin=origin, api_version=api_version)
+        headers = self._get_headers()
+        response = helpers.requester("GET", url, headers=headers)
+
+        return {
+            "body": response.json(),
+            "headers": response.headers,
+        }
+
+    def get_signal(self, signal_code: str) -> v3.Response:
+        """
+        GET Vehicle.signals/{signal_code}
+
+        Args:
+            signal_code (str): The code of the signal to retrieve.
+            e.g. "odometer-travelleddistance"
+
+        Returns:
+            Response: smartcar.response.v3.Response
+        """
+        origin = config.VEHICLE_API_ORIGIN
+        api_version = "3"
+        path = f"signals/{signal_code}"
+        url = self._format_url(path, origin=origin, api_version=api_version)
+        headers = self._get_headers()
+        response = helpers.requester("GET", url, headers=headers)
+
+        return {
+            "body": response.json(),
+            "headers": response.headers,
+        }
+
+    def vin(self) -> v2.Vin:
         """
         GET Vehicle.vin
 
@@ -64,9 +107,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def charge(self) -> types.Charge:
+    def charge(self) -> v2.Charge:
         """
         GET Vehicle.charge
 
@@ -80,9 +123,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def battery(self) -> types.Battery:
+    def battery(self) -> v2.Battery:
         """
         GET Vehicle.battery
 
@@ -98,9 +141,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def battery_capacity(self) -> types.BatteryCapacity:
+    def battery_capacity(self) -> v2.BatteryCapacity:
         """
         GET Vehicle.battery_capacity
 
@@ -114,9 +157,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def nominal_capacity(self) -> types.NominalCapcity:
+    def nominal_capacity(self) -> v2.NominalCapcity:
         """
         GET Vehicle.nominal_capacity
         Returns:
@@ -136,9 +179,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def fuel(self) -> types.Fuel:
+    def fuel(self) -> v2.Fuel:
         """
         GET Vehicle.fuel
 
@@ -153,9 +196,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def tire_pressure(self) -> types.TirePressure:
+    def tire_pressure(self) -> v2.TirePressure:
         """
         GET Vehicle.tire_pressure
 
@@ -172,9 +215,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def engine_oil(self) -> types.EngineOil:
+    def engine_oil(self) -> v2.EngineOil:
         """
         GET Vehicle.engine_oil
 
@@ -188,9 +231,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def odometer(self) -> types.Odometer:
+    def odometer(self) -> v2.Odometer:
         """
         GET Vehicle.odometer
 
@@ -204,11 +247,11 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
     def service_history(
         self, start_date: Optional[str] = None, end_date: Optional[str] = None
-    ) -> types.ServiceHistory:
+    ) -> v2.ServiceHistory:
         """
         Returns a list of all the service records performed on the vehicle,
         filtered by the optional date range. If no dates are specified, records from the
@@ -239,9 +282,9 @@ class Vehicle(object):
             params["endDate"] = end_date
 
         response = helpers.requester("GET", url, headers=headers, params=params)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def diagnostic_system_status(self) -> types.DiagnosticSystemStatus:
+    def diagnostic_system_status(self) -> v2.DiagnosticSystemStatus:
         """
         GET Vehicle.diagnostic_system_status
 
@@ -258,9 +301,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def diagnostic_trouble_codes(self) -> types.DiagnosticTroubleCodes:
+    def diagnostic_trouble_codes(self) -> v2.DiagnosticTroubleCodes:
         """
         GET Vehicle.diagnostic_trouble_codes
 
@@ -277,9 +320,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def location(self) -> types.Location:
+    def location(self) -> v2.Location:
         """
         GET Vehicle.location
 
@@ -293,7 +336,7 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
     def permissions(self, paging: dict = None):
         """
@@ -324,9 +367,9 @@ class Vehicle(object):
                 "GET", url, headers=headers, params={"limit": limit, "offset": offset}
             )
 
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def attributes(self) -> types.Attributes:
+    def attributes(self) -> v2.Attributes:
         """
         GET Vehicle.attributes
 
@@ -341,9 +384,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def get_charge_limit(self) -> types.ChargeLimit:
+    def get_charge_limit(self) -> v2.ChargeLimit:
         """
         GET Vehicle.get_charge_limit
 
@@ -357,9 +400,9 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
-    def lock_status(self) -> types.LockStatus:
+    def lock_status(self) -> v2.LockStatus:
         """
             GET Vehicle.lock_status
 
@@ -381,13 +424,13 @@ class Vehicle(object):
         url = self._format_url(path)
         headers = self._get_headers()
         response = helpers.requester("GET", url, headers=headers)
-        return types.select_named_tuple(path, response)
+        return v2.select_named_tuple(path, response)
 
     # ===========================================
     # Action (POST) Requests
     # ===========================================
 
-    def lock(self) -> types.Status:
+    def lock(self) -> v2.Status:
         """
         POST Vehicle.lock
 
@@ -402,9 +445,9 @@ class Vehicle(object):
         response = helpers.requester(
             "POST", url, headers=headers, json={"action": "LOCK"}
         )
-        return types.select_named_tuple("lock", response)
+        return v2.select_named_tuple("lock", response)
 
-    def unlock(self) -> types.Status:
+    def unlock(self) -> v2.Status:
         """
         POST Vehicle.unlock
 
@@ -419,9 +462,9 @@ class Vehicle(object):
         response = helpers.requester(
             "POST", url, headers=headers, json={"action": "UNLOCK"}
         )
-        return types.select_named_tuple("unlock", response)
+        return v2.select_named_tuple("unlock", response)
 
-    def start_charge(self) -> types.Status:
+    def start_charge(self) -> v2.Status:
         """
         POST Vehicle.start_charge
 
@@ -436,9 +479,9 @@ class Vehicle(object):
         response = helpers.requester(
             "POST", url, headers=headers, json={"action": "START"}
         )
-        return types.select_named_tuple("start_charge", response)
+        return v2.select_named_tuple("start_charge", response)
 
-    def stop_charge(self) -> types.Status:
+    def stop_charge(self) -> v2.Status:
         """
         POST Vehicle.stop_charge
 
@@ -453,9 +496,9 @@ class Vehicle(object):
         response = helpers.requester(
             "POST", url, headers=headers, json={"action": "STOP"}
         )
-        return types.select_named_tuple("stop_charge", response)
+        return v2.select_named_tuple("stop_charge", response)
 
-    def set_charge_limit(self, limit) -> types.Status:
+    def set_charge_limit(self, limit) -> v2.Status:
         """
         POST Vehicle.set_charge_limit
 
@@ -470,9 +513,9 @@ class Vehicle(object):
         response = helpers.requester(
             "POST", url, headers=headers, json={"limit": limit}
         )
-        return types.select_named_tuple("set_charge_limit", response)
+        return v2.select_named_tuple("set_charge_limit", response)
 
-    def send_destination(self, latitude, longitude) -> types.Action:
+    def send_destination(self, latitude, longitude) -> v2.Action:
         """
         POST Vehicle.send_destination
 
@@ -490,7 +533,7 @@ class Vehicle(object):
             headers=headers,
             json={"latitude": latitude, "longitude": longitude},
         )
-        return types.select_named_tuple("send_destination", response)
+        return v2.select_named_tuple("send_destination", response)
 
     @staticmethod
     def _batch_path_response(
@@ -502,7 +545,7 @@ class Vehicle(object):
                 "sc-request-id"
             )
             # use lambda default args to avoid issues with closures
-            return lambda p=path, r=path_response: types.select_named_tuple(p, r)
+            return lambda p=path, r=path_response: v2.select_named_tuple(p, r)
 
         # if individual response is erroneous, attach a lambda that returns a SmartcarException
         def _attribute_raise_exception(smartcar_exception):
@@ -560,16 +603,16 @@ class Vehicle(object):
             )
 
         # STEP 3 - Attach Meta to batch_dict
-        batch_dict["meta"] = types.build_meta(response.headers)
+        batch_dict["meta"] = v2.build_meta(response.headers)
 
         # STEP 4 - Transform batch_dict into a namedtuple
-        return types.generate_named_tuple(batch_dict, "batch")
+        return v2.generate_named_tuple(batch_dict, "batch")
 
     # ===========================================
     # DELETE requests
     # ===========================================
 
-    def disconnect(self) -> types.Status:
+    def disconnect(self) -> v2.Status:
         """
         Disconnect this vehicle from the connected application.
 
@@ -586,13 +629,13 @@ class Vehicle(object):
         url = self._format_url("application")
         headers = self._get_headers(need_unit_system=False)
         response = helpers.requester("DELETE", url, headers=headers)
-        return types.select_named_tuple("disconnect", response)
+        return v2.select_named_tuple("disconnect", response)
 
     # ===========================================
     # Webhook requests
     # ===========================================
 
-    def subscribe(self, webhook_id: str) -> types.Subscribe:
+    def subscribe(self, webhook_id: str) -> v2.Subscribe:
         """
         Subscribe a vehicle to a webhook
 
@@ -605,9 +648,9 @@ class Vehicle(object):
         url = self._format_url(f"webhooks/{webhook_id}")
         headers = self._get_headers(need_unit_system=False)
         response = helpers.requester("POST", url, headers=headers)
-        return types.select_named_tuple("subscribe", response)
+        return v2.select_named_tuple("subscribe", response)
 
-    def unsubscribe(self, amt: str, webhook_id: str) -> types.Status:
+    def unsubscribe(self, amt: str, webhook_id: str) -> v2.Status:
         """
         Subscribe a vehicle to a webhook
 
@@ -623,7 +666,7 @@ class Vehicle(object):
         # Note: Authorization header is different, compared to the other methods
         headers = {"Authorization": f"Bearer {amt}"}
         response = helpers.requester("DELETE", url, headers=headers)
-        return types.select_named_tuple("unsubscribe", response)
+        return v2.select_named_tuple("unsubscribe", response)
 
     # ===========================================
     # General Purpose Request Method
@@ -631,7 +674,7 @@ class Vehicle(object):
 
     def request(
         self, method: str, path: str, body: dict = {}, headers: dict = {}
-    ) -> types.Response:
+    ) -> v2.Response:
         """
         Utility method to make a request to a Smartcar endpoint - can be used
         to make requests to brand specific endpoints.
@@ -660,7 +703,7 @@ class Vehicle(object):
 
         response = helpers.requester(method, url, headers=headers, json=body)
 
-        return types.select_named_tuple("request", response)
+        return v2.select_named_tuple("request", response)
 
     # ===========================================
     # Utility

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -694,12 +694,14 @@ class Vehicle(object):
             return f"?flags={helpers.format_flag_query(self._flags)}"
         return ""
 
-    def _format_url(self, path: str) -> str:
+    def _format_url(self, path: str, **kwargs) -> str:
         """
         Returns (str): Base url with current API version.
         User can change api_version attribute at will.
         """
-        return f"{config.API_URL}/v{self._api_version}/vehicles/{self.vehicle_id}/{path}{self._format_query_params()}"
+        origin = kwargs.get("origin") or config.API_ORIGIN
+        api_version = kwargs.get("api_version") or self._api_version
+        return f"{origin}/v{api_version}/vehicles/{self.vehicle_id}/{path}{self._format_query_params()}"
 
     def _get_headers(self, need_unit_system: bool = True) -> dict:
         """

--- a/smartcar/vehicle.py
+++ b/smartcar/vehicle.py
@@ -76,7 +76,7 @@ class Vehicle(object):
 
         Args:
             signal_code (str): The code of the signal to retrieve.
-            e.g. "odometer-travelleddistance"
+            e.g. "odometer-traveleddistance"
 
         Returns:
             Response: smartcar.response.v3.Response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import smartcar as sc
@@ -22,6 +23,14 @@ def client():
     """
     client = sc.AuthClient(*ah.get_auth_client_params())
     yield client
+
+
+# V3 vehicle fixture
+@pytest.fixture(scope="session")
+def v3_vehicle():
+    vehicle_id = os.environ.get("E2E_SMARTCAR_V3_TEST_VEHICLE_ID")
+    access_token = os.environ.get("E2E_SMARTCAR_V3_TEST_ACCESS_TOKEN")
+    yield sc.Vehicle(vehicle_id, access_token)
 
 
 # # Chevy Volt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,12 @@ def client():
 # V3 vehicle fixture
 @pytest.fixture(scope="session")
 def v3_vehicle():
-    vehicle_id = os.environ.get("E2E_SMARTCAR_V3_TEST_VEHICLE_ID")
-    access_token = os.environ.get("E2E_SMARTCAR_V3_TEST_ACCESS_TOKEN")
+    vehicle_id = os.environ.get(
+        "E2E_SMARTCAR_V3_TEST_VEHICLE_ID", "tst2e255-d3c8-4f90-9fec-e6e68b98e9cb"
+    )
+    access_token = os.environ.get(
+        "E2E_SMARTCAR_V3_TEST_ACCESS_TOKEN", "test-data-token"
+    )
     yield sc.Vehicle(vehicle_id, access_token)
 
 

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -29,6 +29,18 @@ def test_get_user_and_meta_request_id(access):
     assert res.meta.request_id is not None
 
 
+def test_get_vehicle_v3_endpoint(v3_vehicle):
+    response = smartcar.smartcar.get_vehicle(
+        v3_vehicle.access_token, v3_vehicle.vehicle_id
+    )
+    assert response is not None
+    assert type(response) == dict
+    assert "body" in response
+    assert "headers" in response
+    assert "id" in response["body"]
+    assert "attributes" in response["body"]
+
+
 def test_get_vehicles(access):
     res = get_vehicles(access.access_token)
     assert res.vehicles is not None

--- a/tests/e2e/test_smartcar.py
+++ b/tests/e2e/test_smartcar.py
@@ -9,7 +9,7 @@ from smartcar import (
     get_connections,
     delete_connections,
 )
-import smartcar.types as types
+import smartcar.response.v2 as v2
 import tests.auth_helpers as ah
 
 
@@ -33,7 +33,7 @@ def test_get_vehicles(access):
     res = get_vehicles(access.access_token)
     assert res.vehicles is not None
     assert res.paging is not None
-    assert type(res.paging) == types.Paging
+    assert type(res.paging) == v2.Paging
 
 
 def test_get_vehicles_with_paging(access):

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -12,6 +12,7 @@ def test_get_signals(v3_vehicle):
     assert "headers" in response
     assert "data" in response["body"]
 
+
 def test_get_signal(v3_vehicle):
     signal_code = "odometer-traveleddistance"
     response = v3_vehicle.get_signal(signal_code)

--- a/tests/e2e/test_vehicle.py
+++ b/tests/e2e/test_vehicle.py
@@ -1,13 +1,38 @@
-import smartcar.types as types
+import smartcar.response.v2 as v2
+import smartcar.response.v3 as v3
 from smartcar.exception import SmartcarException
 import tests.auth_helpers as ah
 
 
-# Tests
+def test_get_signals(v3_vehicle):
+    response = v3_vehicle.get_signals()
+    assert response is not None
+    assert type(response) == dict
+    assert "body" in response
+    assert "headers" in response
+    assert "data" in response["body"]
+
+def test_get_signal(v3_vehicle):
+    signal_code = "odometer-traveleddistance"
+    response = v3_vehicle.get_signal(signal_code)
+    assert type(response) == dict
+    assert "body" in response
+    assert "headers" in response
+
+    for key in [
+        "id",
+        "type",
+        "attributes",
+        "meta",
+        "links",
+    ]:
+        assert key in response["body"]
+
+
 def test_vin_and_meta(chevy_volt):
     vin = chevy_volt.vin()
     assert vin is not None
-    assert type(vin) == types.Vin
+    assert type(vin) == v2.Vin
     assert vin._fields == ("vin", "meta")
     assert isinstance(vin.meta, tuple)
 
@@ -15,7 +40,7 @@ def test_vin_and_meta(chevy_volt):
 def test_charge(chevy_volt):
     charge = chevy_volt.charge()
     assert charge is not None
-    assert type(charge) == types.Charge
+    assert type(charge) == v2.Charge
     assert charge._fields == ("is_plugged_in", "state", "meta")
     assert charge.is_plugged_in is not None
 
@@ -23,21 +48,21 @@ def test_charge(chevy_volt):
 def test_battery(chevy_volt):
     battery = chevy_volt.battery()
     assert battery is not None
-    assert type(battery) == types.Battery
+    assert type(battery) == v2.Battery
     assert battery._fields == ("percent_remaining", "range", "meta")
 
 
 def test_battery_capacity(chevy_volt):
     battery_capacity = chevy_volt.battery_capacity()
     assert battery_capacity is not None
-    assert type(battery_capacity) == types.BatteryCapacity
+    assert type(battery_capacity) == v2.BatteryCapacity
     assert battery_capacity._fields == ("capacity", "meta")
 
 
 def test_nominal_capacity(chevy_volt):
     nominal_capacity = chevy_volt.nominal_capacity()
     assert nominal_capacity is not None
-    assert type(nominal_capacity) == types.NominalCapcity
+    assert type(nominal_capacity) == v2.NominalCapcity
     assert nominal_capacity._fields == (
         "availableCapacities",
         "capacity",
@@ -49,14 +74,14 @@ def test_nominal_capacity(chevy_volt):
 def test_fuel(chevy_volt):
     fuel = chevy_volt.fuel()
     assert fuel is not None
-    assert type(fuel) == types.Fuel
+    assert type(fuel) == v2.Fuel
     assert fuel._fields == ("range", "percent_remaining", "amount_remaining", "meta")
 
 
 def test_tire_pressure(chevy_volt):
     tire_pressure = chevy_volt.tire_pressure()
     assert tire_pressure is not None
-    assert type(tire_pressure) == types.TirePressure
+    assert type(tire_pressure) == v2.TirePressure
     assert tire_pressure._fields == (
         "front_left",
         "front_right",
@@ -69,42 +94,42 @@ def test_tire_pressure(chevy_volt):
 def test_engine_oil(chevy_volt):
     engine_oil = chevy_volt.engine_oil()
     assert engine_oil is not None
-    assert type(engine_oil) == types.EngineOil
+    assert type(engine_oil) == v2.EngineOil
     assert engine_oil._fields == ("life_remaining", "meta")
 
 
 def test_odometer(chevy_volt):
     odometer = chevy_volt.odometer()
     assert odometer is not None
-    assert type(odometer) == types.Odometer
+    assert type(odometer) == v2.Odometer
     assert odometer._fields == ("distance", "meta")
 
 
 def test_location(chevy_volt):
     location = chevy_volt.location()
     assert location is not None
-    assert type(location) == types.Location
+    assert type(location) == v2.Location
     assert location._fields == ("latitude", "longitude", "meta")
 
 
 def test_attributes(chevy_volt):
     attributes = chevy_volt.attributes()
     assert attributes is not None
-    assert type(attributes) == types.Attributes
+    assert type(attributes) == v2.Attributes
     assert attributes._fields == ("id", "make", "model", "year", "meta")
 
 
 def test_get_charge_limit(ford_car):
     charge_limit = ford_car.get_charge_limit()
     assert charge_limit is not None
-    assert type(charge_limit) == types.ChargeLimit
+    assert type(charge_limit) == v2.ChargeLimit
     assert charge_limit._fields == ("limit", "meta")
 
 
 def test_lock_status(chevy_volt):
     lock_status = chevy_volt.lock_status()
     assert lock_status is not None
-    assert type(lock_status) == types.LockStatus
+    assert type(lock_status) == v2.LockStatus
     assert lock_status._fields == (
         "is_locked",
         "doors",
@@ -119,35 +144,35 @@ def test_lock_status(chevy_volt):
 def test_lock(chevy_volt):
     response = chevy_volt.lock()
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
 def test_unlock(chevy_volt):
     response = chevy_volt.unlock()
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
 def test_start_charge(ford_car):
     response = ford_car.start_charge()
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
 def test_stop_charge(ford_car):
     response = ford_car.stop_charge()
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
 def test_set_charge_limit(ford_car):
     response = ford_car.set_charge_limit(0.7)
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
@@ -155,14 +180,14 @@ def test_send_destination(ford_car):
     # The latitude and longitude of the Empire State Building in New York, USA.
     response = ford_car.send_destination(40.748817, -73.985428)
     assert response.status == "success"
-    assert type(response) == types.Action
+    assert type(response) == v2.Action
     assert response._fields == ("status", "message", "meta")
 
 
 def test_service_history(ford_car):
     response = ford_car.service_history("2023-05-20", "2024-02-10")
     assert isinstance(
-        response, types.ServiceHistory
+        response, v2.ServiceHistory
     ), "Response should be an instance of ServiceHistory"
     assert hasattr(response, "_fields"), "Response should have '_fields' attribute"
     assert "items" in response._fields, "'items' should be a key in the response fields"
@@ -185,21 +210,21 @@ def test_service_history(ford_car):
 def test_diagnostic_system_status(ford_car):
     diagnostic_status = ford_car.diagnostic_system_status()
     assert diagnostic_status is not None
-    assert isinstance(diagnostic_status, types.DiagnosticSystemStatus)
+    assert isinstance(diagnostic_status, v2.DiagnosticSystemStatus)
     assert diagnostic_status._fields == ("systems", "meta")
 
     for system in diagnostic_status.systems:
-        assert isinstance(system, types.DiagnosticSystem)
+        assert isinstance(system, v2.DiagnosticSystem)
 
 
 def test_diagnostic_trouble_codes(ford_car):
     dtc_response = ford_car.diagnostic_trouble_codes()
     assert dtc_response is not None
-    assert isinstance(dtc_response, types.DiagnosticTroubleCodes)
+    assert isinstance(dtc_response, v2.DiagnosticTroubleCodes)
     assert dtc_response._fields == ("active_codes", "meta")
 
     for code in dtc_response.active_codes:
-        assert isinstance(code, types.DiagnosticTroubleCode)
+        assert isinstance(code, v2.DiagnosticTroubleCode)
 
 
 def test_batch_diagnostics(ford_car):
@@ -214,12 +239,12 @@ def test_batch_diagnostics(ford_car):
     diagnostic_status = batch_response.diagnostic_system_status()
     assert diagnostic_status is not None
     for system in diagnostic_status.systems:
-        assert isinstance(system, types.DiagnosticSystem)
+        assert isinstance(system, v2.DiagnosticSystem)
 
     dtc_response = batch_response.diagnostic_trouble_codes()
     assert dtc_response is not None
     for code in dtc_response.active_codes:
-        assert isinstance(code, types.DiagnosticTroubleCode)
+        assert isinstance(code, v2.DiagnosticTroubleCode)
 
 
 def test_batch_success(chevy_volt):
@@ -296,14 +321,14 @@ def test_batch_unauthorized_permission(chevy_volt_limited_scope):
 def test_permissions(chevy_volt):
     permissions = chevy_volt.permissions()
     assert permissions is not None
-    assert type(permissions) == types.Permissions
+    assert type(permissions) == v2.Permissions
     assert permissions._fields == ("permissions", "paging", "meta")
 
 
 def test_permissions_with_paging(chevy_volt):
     permissions = chevy_volt.permissions({"limit": 1, "offset": 1})
     assert permissions is not None
-    assert type(permissions) == types.Permissions
+    assert type(permissions) == v2.Permissions
     assert permissions._fields == ("permissions", "paging", "meta")
     assert permissions.paging.count == len(ah.DEFAULT_SCOPE)
     assert permissions.paging.offset == 1
@@ -320,14 +345,14 @@ def test_webhooks(chevy_volt):
         subscribe = chevy_volt.subscribe(ah.WEBHOOK_ID)
 
         assert subscribe is not None
-        assert type(subscribe) == types.Subscribe
+        assert type(subscribe) == v2.Subscribe
         assert subscribe._fields == ("webhook_id", "vehicle_id", "meta")
 
         unsubscribe = chevy_volt.unsubscribe(
             ah.APPLICATION_MANAGEMENT_TOKEN, ah.WEBHOOK_ID
         )
         assert unsubscribe is not None
-        assert type(unsubscribe) == types.Status
+        assert type(unsubscribe) == v2.Status
         assert unsubscribe._fields == ("status", "meta")
 
 
@@ -335,7 +360,7 @@ def test_request(chevy_volt):
     odometer = chevy_volt.request(
         "GET", "odometer", None, {"sc-unit-system": "imperial"}
     )
-    assert type(odometer) == types.Response
+    assert type(odometer) == v2.Response
     assert odometer.body is not None
     assert isinstance(odometer.meta, tuple)
     assert odometer._fields == ("body", "meta")
@@ -366,7 +391,7 @@ def test_request_with_body(chevy_volt):
         "batch",
         {"requests": [{"path": "/odometer"}, {"path": "/tires/pressure"}]},
     )
-    assert type(batch) is types.Response
+    assert type(batch) is v2.Response
     assert batch.body is not None
     assert isinstance(batch.meta, tuple)
     assert batch.body["responses"][0]["path"] == "/odometer"
@@ -395,5 +420,5 @@ def test_setting_unit_system(chevy_volt):
 def test_disconnect(chevy_volt):
     disconnected = chevy_volt.disconnect()
     assert disconnected is not None
-    assert type(disconnected) == types.Status
+    assert type(disconnected) == v2.Status
     assert disconnected._fields == ("status", "meta")

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,10 +1,10 @@
-import smartcar.types as types
+import smartcar.response.v2 as v2
 import requests.structures as rs
 
 
 def test_generate_named_tuple():
     test_dict = {"a": True, "b": 100, "c": "apple", "hyphen-to-underscore": True}
-    meta = types.generate_named_tuple(test_dict, "Meta", True)
+    meta = v2.generate_named_tuple(test_dict, "Meta", True)
 
     assert meta.a
     assert meta.b == 100
@@ -20,15 +20,15 @@ def test_select_named_tuple_on_dict():
 
     # Test 1 - No paths matching -> Return "body" as a dictionary (i.e. the else statement)
     test_path_1 = "TESTING"
-    res1 = types.select_named_tuple(test_path_1, mock_user_res_dict)
+    res1 = v2.select_named_tuple(test_path_1, mock_user_res_dict)
     assert res1.id == mock_user_res_dict["body"]["id"]
     assert res1.testing
 
     # Test 2 - Test against one of the predetermined paths in 'select_named_tuple'
     test_path_2 = "user"
-    res2 = types.select_named_tuple(test_path_2, mock_user_res_dict)
+    res2 = v2.select_named_tuple(test_path_2, mock_user_res_dict)
 
-    assert type(res2) == types.User
+    assert type(res2) == v2.User
     assert res2.id == "qwerty123"
 
 
@@ -43,7 +43,7 @@ def test_build_meta():
         }
     )
 
-    meta = types.build_meta(headers)
+    meta = v2.build_meta(headers)
 
     assert meta.request_id == "36ab27d0-fd9d-4455-823a-ce30af709ffc"
     assert meta.data_age == "2023-05-04T07:20:50.844Z"


### PR DESCRIPTION
This PR adds two methods to the Vehicle class, and one to the smartcar namespace:
- get_signals - https://smartcar.com/docs/api-reference/get-signals
- get_signal - https://smartcar.com/docs/api-reference/get-signal
- get_vehicle - https://smartcar.com/docs/api-reference/get-vehicle

This PR introduces the v3 response type, i.e. a dict with keys of "body" and "headers".

Also applies a refactor to separate v2 and v3 return types

resolves CAPIE-696