### PR TITLE
chore: rm build artifacts before publish

### DIFF
--- a/.buddy/cd.yml
+++ b/.buddy/cd.yml
@@ -37,6 +37,7 @@
       docker_image_tag: 3.13
       execute_commands:
         - pip install build twine
+        - rm -rf dist build *.egg-info
         - python -m build
         - twine upload --non-interactive dist/* -u __token__ -p $PYPI_TOKEN
       cached_dirs:


### PR DESCRIPTION
This PR adds a manual step before building distribution package. Removes the existing build before building and publishing.