### PR TITLE
docs: add maintenance-mode deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Smartcar Python Backend SDK [![Build Status][ci-image]][ci-url] [![PyPI version][pypi-image]][pypi-url]
 
+> **Maintenance mode.** This SDK receives security patches through December 1, 2026, then no further updates, including security. The package stays published and existing integrations keep working. For new integrations, call the Smartcar API directly over HTTP: [Making API Requests](https://smartcar.com/docs/getting-started/how-to/making-api-requests).
+
 Python package to quickly integrate Smartcar API
 
 ## Resources


### PR DESCRIPTION
Adds the maintenance-mode deprecation banner to the README, matching the backend SDK maintenance-mode announcement: security patches through December 1, 2026, then no further updates. Points new integrations to direct HTTP over the v3 API.

ENG-2199